### PR TITLE
Fixes for connections

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -93,7 +93,9 @@ class NEXParser extends EventEmitter {
 			serverAddress = discriminator;
 		}
 
-		let connection = this.connections.find(connection => connection.discriminator === discriminator);
+		// * Find the latest connection to avoid broken packets
+		// * when disconnecting and reconnecting to the same server.
+		let connection = this.connections.findLast(connection => connection.discriminator === discriminator);
 
 		let newConnection = false;
 		if (!connection) {


### PR DESCRIPTION
- Add connections after validating the packet to filter unrelated packets when using packet dumps from an access point.
- When searching for an existing connection, find the last one to avoid broken packets when disconnecting and reconnecting to the same server.