### PR TITLE
Decrease NEX version requirement on some MM fields

### DIFF
--- a/src/protocols/requests/matchmake_extension.js
+++ b/src/protocols/requests/matchmake_extension.js
@@ -357,7 +357,7 @@ class AutoMatchmakeWithSearchCriteria_PostponeRequest {
 				__typeValue: this.anyGathering
 			},
 			strMessage: {
-				__typeName: 'AnyDataHolder',
+				__typeName: 'String',
 				__typeValue: this.strMessage
 			}
 		};

--- a/src/protocols/types/match_making.js
+++ b/src/protocols/types/match_making.js
@@ -156,7 +156,7 @@ class MatchmakeSession extends NEXTypes.Structure {
 		this.m_ApplicationBuffer = stream.readNEXBuffer();
 		this.m_ParticipationCount = stream.readUInt32LE();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (nexVersion.major >= 3 && nexVersion.minor >= 4) {
 			this.m_ProgressScore = stream.readUInt8();
 		}
 
@@ -318,7 +318,7 @@ class MatchmakeSessionSearchCriteria extends NEXTypes.Structure {
 		this.m_ExcludeNonHostPid = stream.readBoolean();
 		this.m_SelectionMethod = stream.readUInt32LE();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (nexVersion.major >= 3 && nexVersion.minor >= 4) {
 			this.m_VacantParticipants = stream.readUInt16LE();
 		}
 


### PR DESCRIPTION
On Wii Sports Club, these fields are present, even though they are supposedly from NEX 3.5. Downgrade NEX version requirement to 3.4.