### PR TITLE
Changes to structure versioning and add NEXTypes.DateTime()

### DIFF
--- a/access.txt
+++ b/access.txt
@@ -28,6 +28,7 @@ Nova-111 | bafe9856
 OlliOlli | 60e5df12
 PIKMIN 3 | f6accfc1
 Pokémon Bank | 9a2961d8
+Pokémon Rumble World | 844f1d0c
 Pokémon X/Y | 876138df
 POKKÉN TOURNAMENT | 6ef3adf1
 PUYOPUYOTETRIS | 4eb0ca36
@@ -48,6 +49,7 @@ Terraria | 3d37fbdb
 TLoZ: Tri Force Heroes | c1621b84
 Trine 2 | f9c35adc
 WARRIORS OROCHI 3 Hyper | d74bb27d
+Wii Karaoke U | dfc5a4ac
 Wii Sports Club | 4d324052
 XenobladeX | 59d7be84
 Yo-kai Watch 2 | 7ab183bb

--- a/nex/nex.txt
+++ b/nex/nex.txt
@@ -52,7 +52,7 @@ Game Party                   | 3.0.1
 Star Wars Pinball            | 3.0.1
 Zen Pinball 2                | 3.0.1
 Mario vs. DK: Tipping Stars  | 3.7.1
-Mario Kart 7                 | 3.4.17
+Mario Kart 7                 | 3.1.0
 Badge Arcade                 | 3.7.16
 Pokémon Bank                 | 3.4.13
 IronFall Invasion            | 3.7.18
@@ -60,3 +60,5 @@ Steel Diver: Sub Wars        | 3.7.18
 Metroid Prime: FF            | 3.9.17
 Team Kirby Clash Deluxe      | 3.10.26
 Yo-kai Watch 2               | 3.6.18
+Wii Karaoke U                | 3.4.0
+Pokémon Rumble World         | 3.8.13

--- a/src/protocols/types/datastore.js
+++ b/src/protocols/types/datastore.js
@@ -569,7 +569,6 @@ class DataStoreChangeMetaParam extends NEXTypes.Structure {
 		};
 
 		if (this.persistenceTarget !== undefined) {
-			// * If NEX 4.x.x (?)
 			data.persistenceTarget = {
 				__typeName: 'DataStorePersistenceTarget',
 				__typeValue: this.persistenceTarget
@@ -899,13 +898,6 @@ class DataStoreSearchParam extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_datastore_version) {
-			nexVersion = stream.connection.title.nex_datastore_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
-
 		this.searchTarget = stream.readUInt8();
 		this.ownerIds = stream.readNEXList(stream.readPID);
 		this.ownerType = stream.readUInt8();
@@ -923,8 +915,16 @@ class DataStoreSearchParam extends NEXTypes.Structure {
 		this.resultOption = stream.readUInt8();
 		this.minimalRatingFrequency = stream.readUInt32LE();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (this._structureHeader.version >= 1) {
 			this.useCache = stream.readBoolean();
+		}
+
+		if (this._structureHeader.version >= 3) {
+			this.totalCountEnabled = stream.readBoolean();
+		}
+
+		if (this._structureHeader.version >= 2) {
+			this.dataTypes = stream.readNEXList(stream.readUInt16LE);
 		}
 	}
 
@@ -1000,6 +1000,20 @@ class DataStoreSearchParam extends NEXTypes.Structure {
 			data.useCache = {
 				__typeName: 'boolean',
 				__typeValue: this.useCache
+			};
+		}
+
+		if (this.totalCountEnabled !== undefined) {
+			data.totalCountEnabled = {
+				__typeName: 'boolean',
+				__typeValue: this.totalCountEnabled
+			};
+		}
+
+		if (this.dataTypes !== undefined) {
+			data.dataTypes = {
+				__typeName: 'List<uint16>',
+				__typeValue: this.dataTypes
 			};
 		}
 

--- a/src/protocols/types/notifications.js
+++ b/src/protocols/types/notifications.js
@@ -8,8 +8,7 @@ class NotificationEvent extends NEXTypes.Structure {
 	 */
 	parse(stream) {
 		// * This has a different structure on the Switch
-		// * On the Switch m_pidSource, m_uiParam1 and m_uiParam2 are uint64
-		// * A 3rd m_uiParam3 uint64 is also added
+		// * On the Switch m_pidSource, m_uiParam1, m_uiParam2 and m_uiParam3 are uint64
 		// * In revision 1 of the protocol on Switch, an additional m_mapParam Map<String, Variant> is added
 
 		const nexVersion = stream.connection.title.nex_version;
@@ -20,7 +19,7 @@ class NotificationEvent extends NEXTypes.Structure {
 		this.m_uiParam2 = stream.readUInt32LE();
 		this.m_strParam = stream.readNEXString();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (nexVersion.major >= 3 && nexVersion.minor >= 4) {
 			this.m_uiParam3 = stream.readUInt32LE();
 		}
 	}

--- a/src/stream.js
+++ b/src/stream.js
@@ -321,8 +321,7 @@ class Stream {
 	 * @returns {number} NEX DateTime
 	 */
 	readNEXDateTime() {
-		// TODO - Return a NEXTypes.DateTime
-		return this.readUInt64LE();
+		return new NEXTypes.DateTime(this.readUInt64LE());
 	}
 
 	/**

--- a/src/titles.json
+++ b/src/titles.json
@@ -499,8 +499,8 @@
         "access_key": "6181dff1",
         "nex_version": {
             "major": 3,
-            "minor": 4,
-            "patch": 17
+            "minor": 1,
+            "patch": 0
         },
         "nex_match_making_version": {
             "major": 2,
@@ -569,6 +569,24 @@
             "major": 3,
             "minor": 6,
             "patch": 18
+        }
+    },
+    {
+        "name": "Wii Karaoke U",
+        "access_key": "dfc5a4ac",
+        "nex_version": {
+            "major": 3,
+            "minor": 4,
+            "patch": 0
+        }
+    },
+    {
+        "name": "Pokémon Rumble World",
+        "access_key": "844f1d0c",
+        "nex_version": {
+            "major": 3,
+            "minor": 7,
+            "patch": 1
         }
     },
     {

--- a/src/types.js
+++ b/src/types.js
@@ -133,7 +133,7 @@ class RVConnectionData extends Structure {
 		this.stationUrlSpecial = stream.readNEXStationURL();
 
 		if (this._structureHeader.version >= 1) {
-			this.currentUTCTime = stream.readUInt64LE();
+			this.currentUTCTime = stream.readNEXDateTime();
 		}
 	}
 
@@ -214,7 +214,60 @@ class StationURL {
 	}
 }
 
-class DateTime { }
+class DateTime {
+	/**
+	 *
+	 * @param {bigint} value DateTime value
+	 */
+	constructor(value) {
+		this.value = value;
+
+	}
+
+	getSeconds() {
+		return Number(this.value & 63n)
+	}
+
+	getMinutes() {
+		return Number((this.value >> 6n) & 63n)
+	}
+
+	getHours() {
+		return Number((this.value >> 12n) & 31n)
+	}
+
+	getDay() {
+		return Number((this.value >> 17n) & 31n)
+	}
+
+	getMonth() {
+		return Number((this.value >> 22n) & 15n) - 1
+	}
+
+	getYear() {
+		return Number(this.value >> 26n)
+	}
+
+	standard() {
+		return new Date(Date.UTC(
+			this.getYear(),
+			this.getMonth(),
+			this.getDay(),
+			this.getHours(),
+			this.getMinutes(),
+			this.getSeconds()
+		))
+	}
+
+	toJSON() {
+		return {
+			date: {
+				__typeName: 'Date',
+				__typeValue: this.standard()
+			}
+		};
+	}
+}
 
 class ResultRange extends Structure {
 	/**


### PR DESCRIPTION
## Additions

- Two new games have been added to the title list: Pokémon Rumble World and Wii Karaoke U.
- The `NEXTypes.DateTime()` class has been added. The class shows the NEX DateTime as a standard datetime. Note that the `Date` class requires the month value as an index, so we have to decrease the `getMonth()` value by 1. Preview on GUI app:

![image](https://github.com/PretendoNetwork/nex-viewer/assets/112760654/72b313b1-aaa3-4140-9c4c-27e09eec2418)

- The `totalCountEnabled` and `dataTypes` fields have been added to `DataStoreSearchParam`. These fields were previously thought to be only on the Switch, but they have been present since around NEX 3.7 or 3.8. It's not clear in what versions the fields were added, so we just check the structure version.
Also, it can be seen that the `totalCountEnabled` field appears on a later revision than the `dataTypes` param. This is because Pokémon Rumble World only has structure revision 2 and the `totalCountEnabled` param isn't there, so it has appeared on revision 3 and between the other two fields.

## Changes

- The Mario Kart 7 NEX version has been decreased to 3.1, as we have discussed previously.
- The `m_uiParam3` param from notification events has been reduced to NEX 3.4, as it appears on Wii Sports Club.