### PR TITLE
Fix recursion of NEX lists

### DIFF
--- a/app/assets/js/renderer.js
+++ b/app/assets/js/renderer.js
@@ -539,7 +539,6 @@ function serializeNEXList(key, value) {
 	let isList = false;
 	let mapKeyTypeName;
 	let mapValueTypeName;
-	let listValueTypeName;
 
 	if (listType.match(MAP_TYPE_REGEX)) {
 		isMap = true;
@@ -548,8 +547,6 @@ function serializeNEXList(key, value) {
 
 	if (listType.match(LIST_TYPE_REGEX)) {
 		isList = true;
-
-		listValueTypeName = listType.match(LIST_TYPE_REGEX)[1];
 	}
 
 	const serializedRMCDataDetails = document.createElement('details');
@@ -579,6 +576,14 @@ function serializeNEXList(key, value) {
 			rmcValueElementDiv.appendChild(rmcValueElementValue);
 
 			serializedRMCDataDetails.appendChild(rmcValueElementDiv);
+		} else if (isList) {
+			const listValue = {};
+			listValue.__typeName = listType;
+			listValue.__typeValue = value;
+
+			const rmcListElementDiv = document.createElement('div');
+			rmcListElementDiv.appendChild(serializeNEXList(`${key}[${i}]`, listValue));
+			serializedRMCDataDetails.appendChild(rmcListElementDiv);
 		} else {
 			if (isMap) {
 				value.key.__typeName = mapKeyTypeName;
@@ -590,18 +595,7 @@ function serializeNEXList(key, value) {
 			const rmcValueElementDetails = document.createElement('details');
 
 			rmcValueElementSummary.appendChild(document.createTextNode(`${key}[${i}] (${listType}):`));
-
-			if (isList) {
-				const listValue = {};
-				listValue.__typeName = listValueTypeName;
-				listValue.__typeValue = value;
-
-				const rmcListElementDiv = document.createElement('div');
-				rmcListElementDiv.appendChild(serializeNEXList(`${key}[${i}]`, listValue));
-				rmcValueElementDetails.appendChild(rmcListElementDiv);
-			} else {
-				rmcValueElementDetails.appendChild(serializeRMCBody(value));
-			}
+			rmcValueElementDetails.appendChild(serializeRMCBody(value));
 
 			rmcValueElementDetails.appendChild(rmcValueElementSummary);
 

--- a/app/assets/js/renderer.js
+++ b/app/assets/js/renderer.js
@@ -501,64 +501,7 @@ function serializeRMCBody(rmcData) {
 
 					serializedRMCDataDiv.appendChild(serializedRMCDataDetails);
 				} else if (isArray(typeValue)) {
-					let listType = typeName.match(LIST_TYPE_REGEX)?.[1] || typeName; // * Support Map lists
-					let isMap = false;
-					let mapKeyTypeName;
-					let mapValueTypeName;
-
-					if (listType.match(MAP_TYPE_REGEX)) {
-						isMap = true;
-						[mapKeyTypeName, mapValueTypeName] = listType.match(MAP_TYPE_REGEX)[1].split(', ');
-					}
-
-					const serializedRMCDataDetails = document.createElement('details');
-					const serializedRMCDataSummary = document.createElement('summary');
-
-					serializedRMCDataSummary.appendChild(document.createTextNode(`${key} (${typeName} length ${typeValue.length})`));
-					serializedRMCDataDetails.appendChild(serializedRMCDataSummary);
-
-					for (let i = 0; i < typeValue.length; i++) {
-						let value = typeValue[i];
-
-						if (isNEXPrimative(listType)) {
-							if (listType === 'Buffer' || listType === 'qBuffer' || listType === 'unknown') {
-								value = toHexString(value.data); // * value is a NodeJS Buffer object
-							}
-
-							const rmcValueElementDiv = document.createElement('div');
-							const rmcValueElementName = document.createElement('span');
-							const rmcValueElementValue = document.createElement('span');
-							rmcValueElementName.classList.add('name');
-							rmcValueElementValue.classList.add('value');
-
-							rmcValueElementName.appendChild(document.createTextNode(`${key}[${i}] (${listType}):`));
-							rmcValueElementValue.appendChild(document.createTextNode(value));
-
-							rmcValueElementDiv.appendChild(rmcValueElementName);
-							rmcValueElementDiv.appendChild(rmcValueElementValue);
-
-							serializedRMCDataDetails.appendChild(rmcValueElementDiv);
-						} else {
-							if (isMap) {
-								value.key.__typeName = mapKeyTypeName;
-								value.value.__typeName = mapValueTypeName;
-							}
-
-							const rmcValueElementDiv = document.createElement('div');
-							const rmcValueElementSummary = document.createElement('summary');
-							const rmcValueElementDetails = document.createElement('details');
-
-							rmcValueElementSummary.appendChild(document.createTextNode(`${key}[${i}] (${listType}):`));
-
-							rmcValueElementDetails.appendChild(serializeRMCBody(value));
-							rmcValueElementDetails.appendChild(rmcValueElementSummary);
-
-							rmcValueElementDiv.appendChild(rmcValueElementDetails);
-
-							serializedRMCDataDetails.appendChild(rmcValueElementDiv);
-						}
-					}
-
+					const serializedRMCDataDetails = serializeNEXList(key, value);
 					serializedRMCDataDiv.appendChild(serializedRMCDataDetails);
 				} else {
 					const rmcValueElementDiv = document.createElement('div');
@@ -580,6 +523,95 @@ function serializeRMCBody(rmcData) {
 	}
 
 	return serializedRMCDataDiv;
+}
+
+/**
+ * @param {string} key Name of NEX list
+ * @param {object} value NEX list to serialize
+ * @returns {Element} HTML element containing serialized NEX list
+ */
+function serializeNEXList(key, value) {
+	const typeName = value.__typeName;
+	let typeValue = value.__typeValue;
+
+	let listType = typeName.match(LIST_TYPE_REGEX)?.[1] || typeName; // * Support Map lists
+	let isMap = false;
+	let isList = false;
+	let mapKeyTypeName;
+	let mapValueTypeName;
+	let listValueTypeName;
+
+	if (listType.match(MAP_TYPE_REGEX)) {
+		isMap = true;
+		[mapKeyTypeName, mapValueTypeName] = listType.match(MAP_TYPE_REGEX)[1].split(', ');
+	}
+
+	if (listType.match(LIST_TYPE_REGEX)) {
+		isList = true;
+
+		listValueTypeName = listType.match(LIST_TYPE_REGEX)[1];
+	}
+
+	const serializedRMCDataDetails = document.createElement('details');
+	const serializedRMCDataSummary = document.createElement('summary');
+
+	serializedRMCDataSummary.appendChild(document.createTextNode(`${key} (${typeName} length ${typeValue.length})`));
+	serializedRMCDataDetails.appendChild(serializedRMCDataSummary);
+
+	for (let i = 0; i < typeValue.length; i++) {
+		let value = typeValue[i];
+
+		if (isNEXPrimative(listType)) {
+			if (listType === 'Buffer' || listType === 'qBuffer' || listType === 'unknown') {
+				value = toHexString(value.data); // * value is a NodeJS Buffer object
+			}
+
+			const rmcValueElementDiv = document.createElement('div');
+			const rmcValueElementName = document.createElement('span');
+			const rmcValueElementValue = document.createElement('span');
+			rmcValueElementName.classList.add('name');
+			rmcValueElementValue.classList.add('value');
+
+			rmcValueElementName.appendChild(document.createTextNode(`${key}[${i}] (${listType}):`));
+			rmcValueElementValue.appendChild(document.createTextNode(value));
+
+			rmcValueElementDiv.appendChild(rmcValueElementName);
+			rmcValueElementDiv.appendChild(rmcValueElementValue);
+
+			serializedRMCDataDetails.appendChild(rmcValueElementDiv);
+		} else {
+			if (isMap) {
+				value.key.__typeName = mapKeyTypeName;
+				value.value.__typeName = mapValueTypeName;
+			}
+
+			const rmcValueElementDiv = document.createElement('div');
+			const rmcValueElementSummary = document.createElement('summary');
+			const rmcValueElementDetails = document.createElement('details');
+
+			rmcValueElementSummary.appendChild(document.createTextNode(`${key}[${i}] (${listType}):`));
+
+			if (isList) {
+				const listValue = {};
+				listValue.__typeName = listValueTypeName;
+				listValue.__typeValue = value;
+
+				const rmcListElementDiv = document.createElement('div');
+				rmcListElementDiv.appendChild(serializeNEXList(`${key}[${i}]`, listValue));
+				rmcValueElementDetails.appendChild(rmcListElementDiv);
+			} else {
+				rmcValueElementDetails.appendChild(serializeRMCBody(value));
+			}
+
+			rmcValueElementDetails.appendChild(rmcValueElementSummary);
+
+			rmcValueElementDiv.appendChild(rmcValueElementDetails);
+
+			serializedRMCDataDetails.appendChild(rmcValueElementDiv);
+		}
+	}
+
+	return serializedRMCDataDetails;
 }
 
 document.addEventListener('click', event => {


### PR DESCRIPTION
Since the value of a list is an array and not an object, 2D lists wouldn't work because `serializeRMCBody` doesn't support arrays as input. To fix that, make the list parsing its own function and check if the value is a list.

If it is, create an object with the list type name and value and recurse on the same function.

Before: 
![image](https://github.com/PretendoNetwork/nex-viewer/assets/112760654/bfef45b9-86e9-423e-b29d-8f07406e59d3)


After: 
![image](https://github.com/PretendoNetwork/nex-viewer/assets/112760654/1241a93f-4c22-4e9b-b7cb-c581e1fbd192)
