### PR TITLE
Various fixes

### DIFF
--- a/access.txt
+++ b/access.txt
@@ -1,3 +1,5 @@
+Angry Birds Star Wars 3DS | fbae7416
+Angry Birds Trilogy 3DS | ac4fbf0d
 Animal Crossing: New Leaf | d6f08b40
 Animal Crossing Plaza | 7b9b09cb
 Axiom Verge | 24e0a63b
@@ -9,22 +11,23 @@ FAST Racing NEO | 811aa39f
 FotNS: Ken's Rage 2 | 9994e29c
 Hyrule Warriors | 7fcc1f7c
 Injustice: Gods Among Us | 65e9f4d6
-IronFall Invasion | feb81c7c
+IRONFALL Invasion | feb81c7c
 Kid Icarus Uprising | 58a7e494
 Legend of Kay | 478232f3
 Luigi's Mansion 2 | 3861a9f8
+Mario & Sonic Rio 2016 3DS | a2dbfa39
+Mario & Sonic Rio 2016 Wii U | 63fecb0f
 MARIO & SONIC SOCHI 2014 | 585214a5
+MARIO KART 7 | 6181dff1
 MARIO KART 8 | 25dbf96a
-Mario & Sonic Rio 2016 | 63fecb0f
-Mario Kart 7 | 6181dff1
 Mario Tennis Open | 0fabeff2
 Mario Tennis: Ultra Smash | c69b92a0
 Mario vs. DK: Tipping Stars | d8927c3f
 Metroid Prime: FF | f79fb3c5
 Mighty No. 9 | bb980c2e
 Minecraft: Wii U Edition | f1b61c8e
-NINJA GAIDEN 3: Razor's Edge | f857b4bd
 Nano Assault Neo | 7e484a8e
+NINJA GAIDEN 3: Razor's Edge | f857b4bd
 Nova-111 | bafe9856
 OlliOlli | 60e5df12
 PIKMIN 3 | f6accfc1
@@ -32,8 +35,8 @@ Pokémon Bank | 9a2961d8
 Pokémon Rumble World | 844f1d0c
 Pokémon X/Y | 876138df
 POKKÉN TOURNAMENT | 6ef3adf1
-PUYOPUYOTETRIS | 4eb0ca36
 Puddle | afcffb5c
+PUYOPUYOTETRIS | 4eb0ca36
 RTK 12 | bfede098
 Runner2 | 1084452a
 SI2 | 44adeb87
@@ -51,6 +54,7 @@ TLoZ: Tri Force Heroes | c1621b84
 Trine 2 | f9c35adc
 WARRIORS OROCHI 3 Hyper | d74bb27d
 Wii Karaoke U | dfc5a4ac
+Wii Party U | a5b77314
 Wii Sports Club | 4d324052
 XenobladeX | 59d7be84
 Yo-kai Watch 2 | 7ab183bb

--- a/nex/nex.txt
+++ b/nex/nex.txt
@@ -1,65 +1,70 @@
+Angry Birds Star Wars 3DS    | 3.2.1
+Angry Birds Trilogy 3DS      | 2.7.2
+Animal Crossing: New Leaf    | 3.10.1
+Animal Crossing Plaza        | 3.5.1
 Axiom Verge                  | 3.10.0
-Disney Infinity [2.0]        | 3.5.2
-Disney INFINITY              | 3.5.2
-DISNEY INFINITY 3.0          | 3.9.1
-SONIC LOST WORLD             | 3.3.0
-Trine 2                      | 3.0.1
-LOST REAVERS                 | 3.10.0
-Mario & Sonic Rio 2016       | 3.9.1
+Badge Arcade                 | 3.7.3
+BIOHAZARD REVELATIONS UE     | 3.2.1
 Devil's Third                | 3.6.1
-Xenoblade Chronicles X       | 3.5.5
-XenobladeX                   | 3.5.5
-Mighty No. 9                 | 3.9.1
-MARIO & SONIC SOCHI 2014     | 3.4.0
+Disney INFINITY              | 3.5.2
+Disney Infinity [2.0]        | 3.5.2
+DISNEY INFINITY 3.0          | 3.9.1
 DKC: Tropical Freeze         | 3.4.0
-Minecraft: Wii U Edition     | 3.10.0
 DuckTales: Remastered        | 3.3.0
-POKKÉN TOURNAMENT            | 3.10.0
+FAST Racing NEO              | 3.9.1
 FotNS: Ken's Rage 2          | 3.0.1
-Sonic Transformed            | 3.0.1
-RTK 12                       | 3.4.0
+Game Party                   | 3.0.1
 Hyrule Warriors              | 3.8.0
-PUYOPUYOTETRIS               | 3.5.2
+Injustice: Gods Among Us     | 3.2.1
+IRONFALL Invasion            | 3.7.1
 Legend of Kay                | 3.8.3
-SI2                          | 3.6.1
-Runner2                      | 3.0.1
-Nova-111                     | 3.8.3
-OlliOlli                     | 3.6.1
-Mario Tennis: Ultra Smash    | 3.9.1
-Super Smash Bros.            | 3.6.27
-Wii Sports Club              | 3.4.7
+LOST REAVERS                 | 3.10.0
+Mario & Sonic Rio 2016 3DS   | 3.9.1
+Mario & Sonic Rio 2016 Wii U | 3.9.1
+MARIO & SONIC SOCHI 2014     | 3.4.0
+MARIO KART 7                 | 2.4.3
 MARIO KART 8                 | 3.5.4
-Super Mario Maker            | 3.8.12
-Splatoon                     | 3.8.3
+Mario Tennis Open            | 2.6.1
+Mario Tennis: Ultra Smash    | 3.9.1
+Mario vs. DK: Tipping Stars  | 3.7.1
+Metroid Prime: FF            | 3.9.1
 MH3G HD Ver.                 | 3.0.5
 MH3U                         | 3.0.5
-Animal Crossing Plaza        | 3.5.1
-Star Fox Guard (Demo)        | 3.8.2
-Star Fox Guard               | 3.8.2
-BIOHAZARD REVELATIONS UE     | 3.2.1
-RESIDENT EVIL REVELATIONS    | 3.2.1
-役満 鳳凰                    | 3.6.14
-FAST Racing NEO              | 3.9.1
-TEKKEN TAG 2 Wii U EDITION   | 3.0.1
-WARRIORS OROCHI 3 Hyper      | 3.0.1
-PIKMIN 3                     | 3.3.0
-NINJA GAIDEN 3: Razor's Edge | 3.0.1
-Injustice: Gods Among Us     | 3.2.1
+Mighty No. 9                 | 3.9.1
+Minecraft: Wii U Edition     | 3.10.0
 Nano Assault Neo             | 3.0.1
-Terraria                     | 3.8.3
-Puddle                       | 3.0.1
-Game Party                   | 3.0.1
-Star Wars Pinball            | 3.0.1
-Zen Pinball 2                | 3.0.1
-Mario vs. DK: Tipping Stars  | 3.7.1
-Mario Kart 7                 | 2.4.3
-Badge Arcade                 | 3.7.16
-Pokémon Bank                 | 3.4.13
-IronFall Invasion            | 3.7.18
-Steel Diver: Sub Wars        | 3.7.18
-Metroid Prime: FF            | 3.9.17
-Team Kirby Clash Deluxe      | 3.10.26
-Yo-kai Watch 2               | 3.6.18
-Wii Karaoke U                | 3.4.0
+NINJA GAIDEN 3: Razor's Edge | 3.0.1
+Nova-111                     | 3.8.3
+OlliOlli                     | 3.6.1
+PIKMIN 3                     | 3.3.0
+Pokémon Bank                 | 3.4.12
 Pokémon Rumble World         | 3.8.2
-Mario Tennis Open            | 2.6.1
+POKKÉN TOURNAMENT            | 3.10.0
+Puddle                       | 3.0.1
+PUYOPUYOTETRIS               | 3.5.2
+RESIDENT EVIL REVELATIONS    | 3.2.1
+RTK 12                       | 3.4.0
+Runner2                      | 3.0.1
+SI2                          | 3.6.1
+SONIC LOST WORLD             | 3.3.0
+Sonic Transformed            | 3.0.1
+Splatoon                     | 3.8.3
+Star Fox Guard               | 3.8.2
+Star Fox Guard (Demo)        | 3.8.2
+Star Wars Pinball            | 3.0.1
+Steel Diver: Sub Wars        | 3.7.0
+Super Mario Maker            | 3.8.12
+Super Smash Bros.            | 3.6.27
+Team Kirby Clash Deluxe      | 3.10.1
+TEKKEN TAG 2 Wii U EDITION   | 3.0.1
+Terraria                     | 3.8.3
+Trine 2                      | 3.0.1
+WARRIORS OROCHI 3 Hyper      | 3.0.1
+Wii Karaoke U                | 3.4.0
+Wii Party U                  | 3.3.0
+Wii Sports Club              | 3.4.7
+Xenoblade Chronicles X       | 3.5.5
+XenobladeX                   | 3.5.5
+Yo-kai Watch 2               | 3.6.1
+Zen Pinball 2                | 3.0.1
+役満 鳳凰                    | 3.6.14

--- a/src/packetv0.js
+++ b/src/packetv0.js
@@ -23,6 +23,27 @@ class PacketV0 extends Packet {
 		this.source = this.stream.readUInt8();
 		this.destination = this.stream.readUInt8();
 
+		// * Skip Quazal Net-Z packets
+		if ((this.source & 0xF) === (this.destination & 0xF)) { // * The source and destination ports are the same
+			throw new Error(`Source and destination ports are the same. Source ${this.source}, destination ${this.destination}`);
+		}
+
+		if ((this.source & 0xF0) === 0x10) { // * Source uses DO stream type
+			throw new Error(`Source stream type is DO. Source ${this.source}`);
+		}
+
+		if ((this.source & 0xF0) === 0x50) { // * Source uses NAT stream type
+			throw new Error(`Source stream type is NAT. Source ${this.source}`);
+		}
+
+		if ((this.destination & 0xF0) === 0x10) { // * Destination uses DO stream type
+			throw new Error(`Destination stream type is DO. Destination ${this.destination}`);
+		}
+
+		if ((this.destination & 0xF0) === 0x50) { // * Destination uses NAT stream type
+			throw new Error(`Destination stream type is DO. Destination ${this.destination}`);
+		}
+
 		const typeAndFlags = this.stream.readUInt16LE();
 
 		this.flags = typeAndFlags >> 4;

--- a/src/packetv1.js
+++ b/src/packetv1.js
@@ -42,6 +42,27 @@ class PacketV1 extends Packet {
 		this.source = this.headerStream.readUInt8();
 		this.destination = this.headerStream.readUInt8();
 
+		// * Skip Quazal Net-Z packets
+		if ((this.source & 0xF) === (this.destination & 0xF)) { // * The source and destination ports are the same
+			throw new Error(`Source and destination ports are the same. Source ${this.source}, destination ${this.destination}`);
+		}
+
+		if ((this.source & 0xF0) === 0x10) { // * Source uses DO stream type
+			throw new Error(`Source stream type is DO. Source ${this.source}`);
+		}
+
+		if ((this.source & 0xF0) === 0x50) { // * Source uses NAT stream type
+			throw new Error(`Source stream type is NAT. Source ${this.source}`);
+		}
+
+		if ((this.destination & 0xF0) === 0x10) { // * Destination uses DO stream type
+			throw new Error(`Destination stream type is DO. Destination ${this.destination}`);
+		}
+
+		if ((this.destination & 0xF0) === 0x50) { // * Destination uses NAT stream type
+			throw new Error(`Destination stream type is DO. Destination ${this.destination}`);
+		}
+
 		const typeAndFlags = this.headerStream.readUInt16LE();
 
 		this.flags = typeAndFlags >> 4;

--- a/src/protocols/patches/ranking_legacy.js
+++ b/src/protocols/patches/ranking_legacy.js
@@ -18,6 +18,7 @@ class RankingLegacy {
 		UploadCommonData: 0x05,
 		UnknownMethod0xE: 0x0e,
 		UnknownMethod0xF: 0x0f,
+		GetTotal: 0x10,
 		UploadScoreWithLimit: 0x11,
 		UploadSpecificPeriodScore: 0x14,
 		GetSpecificPeriodDataList: 0x16,
@@ -34,6 +35,7 @@ class RankingLegacy {
 		0x05: RankingLegacy.UploadCommonData,
 		0x0e: RankingLegacy.UnknownMethod0xE,
 		0x0f: RankingLegacy.UnknownMethod0xF,
+		0x10: RankingLegacy.GetTotal,
 		0x11: RankingLegacy.UploadScoreWithLimit,
 		0x14: RankingLegacy.UploadSpecificPeriodScore,
 		0x16: RankingLegacy.GetSpecificPeriodDataList,
@@ -103,6 +105,20 @@ class RankingLegacy {
 			return new Requests.UnknownMethod0xFRequest(stream);
 		} else {
 			return new Responses.UnknownMethod0xFResponse(stream);
+		}
+	}
+
+	/**
+	 *
+	 * @param {RMCMessage} rmcMessage NEX RMC message
+	 * @param {Stream} stream NEX data stream
+	 * @returns {object} Parsed RMC body
+	 */
+	static GetTotal(rmcMessage, stream) {
+		if (rmcMessage.isRequest()) {
+			return new Requests.GetTotalRequest(stream);
+		} else {
+			return new Responses.GetTotalResponse(stream);
 		}
 	}
 

--- a/src/protocols/requests/ranking_legacy.js
+++ b/src/protocols/requests/ranking_legacy.js
@@ -154,6 +154,44 @@ class UnknownMethod0xFRequest {
 	}
 }
 
+class GetTotalRequest {
+	/**
+	 * @param {Stream} stream NEX data stream
+	 */
+	constructor(stream) {
+		this.category = stream.readUInt32LE();
+		this.unknown1 = stream.readUInt8();
+		this.unknown2 = stream.readUInt8();
+		this.unknown3 = stream.readUInt8();
+		this.unknown4 = stream.readUInt32LE();
+	}
+
+	toJSON() {
+		return {
+			category: {
+				__typeName: 'uint32',
+				__typeValue: this.category
+			},
+			unknown1: {
+				__typeName: 'uint8',
+				__typeValue: this.unknown1
+			},
+			unknown2: {
+				__typeName: 'uint8',
+				__typeValue: this.unknown2
+			},
+			unknown3: {
+				__typeName: 'uint8',
+				__typeValue: this.unknown3
+			},
+			unknown4: {
+				__typeName: 'uint32',
+				__typeValue: this.unknown4
+			}
+		};
+	}
+}
+
 class UploadScoreWithLimitRequest {
 	/**
 	 * @param {Stream} stream NEX data stream
@@ -310,6 +348,7 @@ module.exports = {
 	UploadCommonDataRequest,
 	UnknownMethod0xERequest,
 	UnknownMethod0xFRequest,
+	GetTotalRequest,
 	UploadScoreWithLimitRequest,
 	UploadSpecificPeriodScoreRequest,
 	GetSpecificPeriodDataListRequest,

--- a/src/protocols/responses/ranking_legacy.js
+++ b/src/protocols/responses/ranking_legacy.js
@@ -66,6 +66,29 @@ class UnknownMethod0xFResponse {
 	}
 }
 
+class GetTotalResponse {
+	/**
+	 * @param {Stream} stream NEX data stream
+	 */
+	constructor(stream) {
+		this.unknown = stream.readUInt16LE();
+		this.total = stream.readUInt32LE();
+	}
+
+	toJSON() {
+		return {
+			unknown: {
+				__typeName: 'uint16',
+				__typeValue: this.unknown
+			},
+			total: {
+				__typeName: 'uint32',
+				__typeValue: this.total
+			}
+		};
+	}
+}
+
 class UploadScoreWithLimitResponse {
 	/**
 	 * @param {Stream} stream NEX data stream
@@ -157,6 +180,7 @@ module.exports = {
 	UploadCommonDataResponse,
 	UnknownMethod0xEResponse,
 	UnknownMethod0xFResponse,
+	GetTotalResponse,
 	UploadScoreWithLimitResponse,
 	UploadSpecificPeriodScoreResponse,
 	GetSpecificPeriodDataListResponse,

--- a/src/titles.json
+++ b/src/titles.json
@@ -9,6 +9,42 @@
         }
     },
     {
+        "name": "Angry Birds Star Wars 3DS",
+        "access_key": "fbae7416",
+        "nex_version": {
+            "major": 3,
+            "minor": 2,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Angry Birds Trilogy 3DS",
+        "access_key": "ac4fbf0d",
+        "nex_version": {
+            "major": 2,
+            "minor": 7,
+            "patch": 2
+        }
+    },
+    {
+        "name": "Animal Crossing: New Leaf",
+        "access_key": "d6f08b40",
+        "nex_version": {
+            "major": 3,
+            "minor": 10,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Animal Crossing Plaza",
+        "access_key": "7b9b09cb",
+        "nex_version": {
+            "major": 3,
+            "minor": 5,
+            "patch": 1
+        }
+    },
+    {
         "name": "Axiom Verge",
         "access_key": "24e0a63b",
         "nex_version": {
@@ -18,7 +54,34 @@
         }
     },
     {
-        "name": "Disney Infinity [2.0]",
+        "name": "Badge Arcade",
+        "access_key": "82d5962d",
+        "nex_version": {
+            "major": 3,
+            "minor": 7,
+            "patch": 3
+        }
+    },
+    {
+        "name": "BIOHAZARD REVELATIONS UE",
+        "access_key": "59d539a9",
+        "nex_version": {
+            "major": 3,
+            "minor": 2,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Devil's Third",
+        "access_key": "",
+        "nex_version": {
+            "major": 3,
+            "minor": 6,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Disney INFINITY",
         "access_key": "",
         "nex_version": {
             "major": 3,
@@ -27,7 +90,7 @@
         }
     },
     {
-        "name": "Disney INFINITY",
+        "name": "Disney Infinity [2.0]",
         "access_key": "",
         "nex_version": {
             "major": 3,
@@ -45,8 +108,17 @@
         }
     },
     {
-        "name": "SONIC LOST WORLD",
-        "access_key": "69a9fc95",
+        "name": "DKC: Tropical Freeze",
+        "access_key": "7fcf384a",
+        "nex_version": {
+            "major": 3,
+            "minor": 4,
+            "patch": 0
+        }
+    },
+    {
+        "name": "DuckTales: Remastered",
+        "access_key": "1294a96c",
         "nex_version": {
             "major": 3,
             "minor": 3,
@@ -54,12 +126,66 @@
         }
     },
     {
-        "name": "Trine 2",
-        "access_key": "f9c35adc",
+        "name": "FAST Racing NEO",
+        "access_key": "811aa39f",
+        "nex_version": {
+            "major": 3,
+            "minor": 9,
+            "patch": 1
+        }
+    },
+    {
+        "name": "FotNS: Ken's Rage 2",
+        "access_key": "9994e29c",
         "nex_version": {
             "major": 3,
             "minor": 0,
             "patch": 1
+        }
+    },
+    {
+        "name": "Game Party",
+        "access_key": "",
+        "nex_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Hyrule Warriors",
+        "access_key": "7fcc1f7c",
+        "nex_version": {
+            "major": 3,
+            "minor": 8,
+            "patch": 0
+        }
+    },
+    {
+        "name": "Injustice: Gods Among Us",
+        "access_key": "65e9f4d6",
+        "nex_version": {
+            "major": 3,
+            "minor": 2,
+            "patch": 1
+        }
+    },
+    {
+        "name": "IRONFALL Invasion",
+        "access_key": "feb81c7c",
+        "nex_version": {
+            "major": 3,
+            "minor": 7,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Legend of Kay",
+        "access_key": "478232f3",
+        "nex_version": {
+            "major": 3,
+            "minor": 8,
+            "patch": 3
         }
     },
     {
@@ -72,8 +198,8 @@
         }
     },
     {
-        "name": "Mario & Sonic Rio 2016",
-        "access_key": "63fecb0f",
+        "name": "Mario & Sonic Rio 2016 3DS",
+        "access_key": "a2dbfa39",
         "nex_version": {
             "major": 3,
             "minor": 9,
@@ -81,35 +207,8 @@
         }
     },
     {
-        "name": "Devil's Third",
-        "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 6,
-            "patch": 1
-        }
-    },
-    {
-        "name": "Xenoblade Chronicles X",
-        "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 5
-        }
-    },
-    {
-        "name": "XenobladeX",
-        "access_key": "59d7be84",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 5
-        }
-    },
-    {
-        "name": "Mighty No. 9",
-        "access_key": "bb980c2e",
+        "name": "Mario & Sonic Rio 2016 Wii U",
+        "access_key": "63fecb0f",
         "nex_version": {
             "major": 3,
             "minor": 9,
@@ -126,12 +225,84 @@
         }
     },
     {
-        "name": "DKC: Tropical Freeze",
-        "access_key": "7fcf384a",
+        "name": "MARIO KART 7",
+        "access_key": "6181dff1",
+        "nex_version": {
+            "major": 2,
+            "minor": 4,
+            "patch": 3
+        }
+    },
+    {
+        "name": "MARIO KART 8",
+        "access_key": "25dbf96a",
         "nex_version": {
             "major": 3,
-            "minor": 4,
-            "patch": 0
+            "minor": 5,
+            "patch": 4
+        }
+    },
+    {
+        "name": "Mario Tennis Open",
+        "access_key": "0fabeff2",
+        "nex_version": {
+            "major": 2,
+            "minor": 6,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Mario Tennis: Ultra Smash",
+        "access_key": "c69b92a0",
+        "nex_version": {
+            "major": 3,
+            "minor": 9,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Mario vs. DK: Tipping Stars",
+        "access_key": "d8927c3f",
+        "nex_version": {
+            "major": 3,
+            "minor": 7,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Metroid Prime: FF",
+        "access_key": "f79fb3c5",
+        "nex_version": {
+            "major": 3,
+            "minor": 9,
+            "patch": 1
+        }
+    },
+    {
+        "name": "MH3G HD Ver.",
+        "access_key": "",
+        "nex_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 5
+        }
+    },
+    {
+        "name": "MH3U",
+        "access_key": "",
+        "nex_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 5
+        }
+    },
+    {
+        "name": "Mighty No. 9",
+        "access_key": "bb980c2e",
+        "nex_version": {
+            "major": 3,
+            "minor": 9,
+            "patch": 1
         }
     },
     {
@@ -144,26 +315,8 @@
         }
     },
     {
-        "name": "DuckTales: Remastered",
-        "access_key": "1294a96c",
-        "nex_version": {
-            "major": 3,
-            "minor": 3,
-            "patch": 0
-        }
-    },
-    {
-        "name": "POKKÉN TOURNAMENT",
-        "access_key": "6ef3adf1",
-        "nex_version": {
-            "major": 3,
-            "minor": 10,
-            "patch": 0
-        }
-    },
-    {
-        "name": "FotNS: Ken's Rage 2",
-        "access_key": "9994e29c",
+        "name": "Nano Assault Neo",
+        "access_key": "7e484a8e",
         "nex_version": {
             "major": 3,
             "minor": 0,
@@ -171,62 +324,8 @@
         }
     },
     {
-        "name": "Sonic Transformed",
-        "access_key": "b26a3421",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
-    },
-    {
-        "name": "RTK 12",
-        "access_key": "bfede098",
-        "nex_version": {
-            "major": 3,
-            "minor": 4,
-            "patch": 0
-        }
-    },
-    {
-        "name": "Hyrule Warriors",
-        "access_key": "7fcc1f7c",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 0
-        }
-    },
-    {
-        "name": "PUYOPUYOTETRIS",
-        "access_key": "4eb0ca36",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 2
-        }
-    },
-    {
-        "name": "Legend of Kay",
-        "access_key": "478232f3",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 3
-        }
-    },
-    {
-        "name": "SI2",
-        "access_key": "44adeb87",
-        "nex_version": {
-            "major": 3,
-            "minor": 6,
-            "patch": 1
-        }
-    },
-    {
-        "name": "Runner2",
-        "access_key": "1084452a",
+        "name": "NINJA GAIDEN 3: Razor's Edge",
+        "access_key": "f857b4bd",
         "nex_version": {
             "major": 3,
             "minor": 0,
@@ -252,111 +351,57 @@
         }
     },
     {
-        "name": "Mario Tennis: Ultra Smash",
-        "access_key": "c69b92a0",
+        "name": "PIKMIN 3",
+        "access_key": "f6accfc1",
         "nex_version": {
             "major": 3,
-            "minor": 9,
-            "patch": 1
+            "minor": 3,
+            "patch": 0
         }
     },
     {
-        "name": "Super Smash Bros.",
-        "access_key": "2869ba38",
-        "nex_version": {
-            "major": 3,
-            "minor": 6,
-            "patch": 27
-        }
-    },
-    {
-        "name": "Wii Sports Club",
-        "access_key": "4d324052",
+        "name": "Pokémon Bank",
+        "access_key": "9a2961d8",
         "nex_version": {
             "major": 3,
             "minor": 4,
-            "patch": 7
-        }
-    },
-    {
-        "name": "MARIO KART 8",
-        "access_key": "25dbf96a",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 4
-        }
-    },
-    {
-        "name": "Super Mario Maker",
-        "access_key": "9f2b4678",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
             "patch": 12
         }
     },
     {
-        "name": "Splatoon",
-        "access_key": "6f599f81",
+        "name": "Pokémon Rumble World",
+        "access_key": "844f1d0c",
         "nex_version": {
             "major": 3,
             "minor": 8,
-            "patch": 3
+            "patch": 2
         }
     },
     {
-        "name": "MH3G HD Ver.",
-        "access_key": "",
+        "name": "POKKÉN TOURNAMENT",
+        "access_key": "6ef3adf1",
+        "nex_version": {
+            "major": 3,
+            "minor": 10,
+            "patch": 0
+        }
+    },
+    {
+        "name": "Puddle",
+        "access_key": "afcffb5c",
         "nex_version": {
             "major": 3,
             "minor": 0,
-            "patch": 5
+            "patch": 1
         }
     },
     {
-        "name": "MH3U",
-        "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 5
-        }
-    },
-    {
-        "name": "Animal Crossing Plaza",
-        "access_key": "7b9b09cb",
+        "name": "PUYOPUYOTETRIS",
+        "access_key": "4eb0ca36",
         "nex_version": {
             "major": 3,
             "minor": 5,
-            "patch": 1
-        }
-    },
-    {
-        "name": "Star Fox Guard (Demo)",
-        "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
             "patch": 2
-        }
-    },
-    {
-        "name": "Star Fox Guard",
-        "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 2
-        }
-    },
-    {
-        "name": "BIOHAZARD REVELATIONS UE",
-        "access_key": "59d539a9",
-        "nex_version": {
-            "major": 3,
-            "minor": 2,
-            "patch": 1
         }
     },
     {
@@ -369,44 +414,35 @@
         }
     },
     {
-        "name": "役満 鳳凰",
-        "access_key": "23aab2d3",
+        "name": "RTK 12",
+        "access_key": "bfede098",
+        "nex_version": {
+            "major": 3,
+            "minor": 4,
+            "patch": 0
+        }
+    },
+    {
+        "name": "Runner2",
+        "access_key": "1084452a",
+        "nex_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 1
+        }
+    },
+    {
+        "name": "SI2",
+        "access_key": "44adeb87",
         "nex_version": {
             "major": 3,
             "minor": 6,
-            "patch": 14
-        }
-    },
-    {
-        "name": "FAST Racing NEO",
-        "access_key": "811aa39f",
-        "nex_version": {
-            "major": 3,
-            "minor": 9,
             "patch": 1
         }
     },
     {
-        "name": "TEKKEN TAG 2 Wii U EDITION",
-        "access_key": "0f037f64",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
-    },
-    {
-        "name": "WARRIORS OROCHI 3 Hyper",
-        "access_key": "d74bb27d",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
-    },
-    {
-        "name": "PIKMIN 3",
-        "access_key": "f6accfc1",
+        "name": "SONIC LOST WORLD",
+        "access_key": "69a9fc95",
         "nex_version": {
             "major": 3,
             "minor": 3,
@@ -414,8 +450,8 @@
         }
     },
     {
-        "name": "NINJA GAIDEN 3: Razor's Edge",
-        "access_key": "f857b4bd",
+        "name": "Sonic Transformed",
+        "access_key": "b26a3421",
         "nex_version": {
             "major": 3,
             "minor": 0,
@@ -423,17 +459,80 @@
         }
     },
     {
-        "name": "Injustice: Gods Among Us",
-        "access_key": "65e9f4d6",
+        "name": "Splatoon",
+        "access_key": "6f599f81",
         "nex_version": {
             "major": 3,
-            "minor": 2,
+            "minor": 8,
+            "patch": 3
+        }
+    },
+    {
+        "name": "Star Fox Guard",
+        "access_key": "",
+        "nex_version": {
+            "major": 3,
+            "minor": 8,
+            "patch": 2
+        }
+    },
+    {
+        "name": "Star Fox Guard (Demo)",
+        "access_key": "",
+        "nex_version": {
+            "major": 3,
+            "minor": 8,
+            "patch": 2
+        }
+    },
+    {
+        "name": "Star Wars Pinball",
+        "access_key": "ecd0e530",
+        "nex_version": {
+            "major": 3,
+            "minor": 0,
             "patch": 1
         }
     },
     {
-        "name": "Nano Assault Neo",
-        "access_key": "7e484a8e",
+        "name": "Steel Diver: Sub Wars",
+        "access_key": "fb9537fe",
+        "nex_version": {
+            "major": 3,
+            "minor": 7,
+            "patch": 0
+        }
+    },
+    {
+        "name": "Super Mario Maker",
+        "access_key": "9f2b4678",
+        "nex_version": {
+            "major": 3,
+            "minor": 8,
+            "patch": 12
+        }
+    },
+    {
+        "name": "Super Smash Bros.",
+        "access_key": "2869ba38",
+        "nex_version": {
+            "major": 3,
+            "minor": 6,
+            "patch": 27
+        }
+    },
+    {
+        "name": "Team Kirby Clash Deluxe",
+        "access_key": "e0c85605",
+        "nex_version": {
+            "major": 3,
+            "minor": 10,
+            "patch": 1
+        }
+    },
+    {
+        "name": "TEKKEN TAG 2 Wii U EDITION",
+        "access_key": "0f037f64",
         "nex_version": {
             "major": 3,
             "minor": 0,
@@ -450,8 +549,8 @@
         }
     },
     {
-        "name": "Puddle",
-        "access_key": "afcffb5c",
+        "name": "Trine 2",
+        "access_key": "f9c35adc",
         "nex_version": {
             "major": 3,
             "minor": 0,
@@ -459,20 +558,65 @@
         }
     },
     {
-        "name": "Game Party",
+        "name": "WARRIORS OROCHI 3 Hyper",
+        "access_key": "d74bb27d",
+        "nex_version": {
+            "major": 3,
+            "minor": 0,
+            "patch": 1
+        }
+    },
+    {
+        "name": "Wii Karaoke U",
+        "access_key": "dfc5a4ac",
+        "nex_version": {
+            "major": 3,
+            "minor": 4,
+            "patch": 0
+        }
+    },
+    {
+        "name": "Wii Party U",
+        "access_key": "a5b77314",
+        "nex_version": {
+            "major": 3,
+            "minor": 3,
+            "patch": 0
+        }
+    },
+    {
+        "name": "Wii Sports Club",
+        "access_key": "4d324052",
+        "nex_version": {
+            "major": 3,
+            "minor": 4,
+            "patch": 7
+        }
+    },
+    {
+        "name": "Xenoblade Chronicles X",
         "access_key": "",
         "nex_version": {
             "major": 3,
-            "minor": 0,
-            "patch": 1
+            "minor": 5,
+            "patch": 5
         }
     },
     {
-        "name": "Star Wars Pinball",
-        "access_key": "ecd0e530",
+        "name": "XenobladeX",
+        "access_key": "59d7be84",
         "nex_version": {
             "major": 3,
-            "minor": 0,
+            "minor": 5,
+            "patch": 5
+        }
+    },
+    {
+        "name": "Yo-kai Watch 2",
+        "access_key": "7ab183bb",
+        "nex_version": {
+            "major": 3,
+            "minor": 6,
             "patch": 1
         }
     },
@@ -486,120 +630,12 @@
         }
     },
     {
-        "name": "Mario vs. DK: Tipping Stars",
-        "access_key": "d8927c3f",
-        "nex_version": {
-            "major": 3,
-            "minor": 7,
-            "patch": 1
-        }
-    },
-    {
-        "name": "Mario Kart 7",
-        "access_key": "6181dff1",
-        "nex_version": {
-            "major": 2,
-            "minor": 4,
-            "patch": 3
-        }
-    },
-    {
-        "name": "Badge Arcade",
-        "access_key": "82d5962d",
-        "nex_version": {
-            "major": 3,
-            "minor": 7,
-            "patch": 16
-        }
-    },
-    {
-        "name": "Pokémon Bank",
-        "access_key": "9a2961d8",
-        "nex_version": {
-            "major": 3,
-            "minor": 4,
-            "patch": 13
-        }
-    },
-    {
-        "name": "IronFall Invasion",
-        "access_key": "feb81c7c",
-        "nex_version": {
-            "major": 3,
-            "minor": 7,
-            "patch": 18
-        }
-    },
-    {
-        "name": "Steel Diver: Sub Wars",
-        "access_key": "fb9537fe",
-        "nex_version": {
-            "major": 3,
-            "minor": 7,
-            "patch": 18
-        }
-    },
-    {
-        "name": "Metroid Prime: FF",
-        "access_key": "f79fb3c5",
-        "nex_version": {
-            "major": 3,
-            "minor": 9,
-            "patch": 17
-        }
-    },
-    {
-        "name": "Team Kirby Clash Deluxe",
-        "access_key": "e0c85605",
-        "nex_version": {
-            "major": 3,
-            "minor": 10,
-            "patch": 26
-        }
-    },
-    {
-        "name": "Yo-kai Watch 2",
-        "access_key": "7ab183bb",
+        "name": "役満 鳳凰",
+        "access_key": "23aab2d3",
         "nex_version": {
             "major": 3,
             "minor": 6,
-            "patch": 18
-        }
-    },
-    {
-        "name": "Wii Karaoke U",
-        "access_key": "dfc5a4ac",
-        "nex_version": {
-            "major": 3,
-            "minor": 4,
-            "patch": 0
-        }
-    },
-    {
-        "name": "Pokémon Rumble World",
-        "access_key": "844f1d0c",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 2
-        }
-    },
-    {
-        "name": "Mario Tennis Open",
-        "access_key": "0fabeff2",
-        "nex_version": {
-            "major": 2,
-            "minor": 6,
-            "patch": 1
-        }
-    },
-    {
-        "name": "Animal Crossing: New Leaf",
-        "access_key": "d6f08b40",
-        "nex_version": {
-            "major": 0,
-            "minor": 0,
-            "patch": 0
+            "patch": 14
         }
     },
     {


### PR DESCRIPTION
- Skip Quazal Net-Z packets when parsing
  - Quazal Net-Z is out of scope, we only support Rendez-Vous. Allows us to filter false positives.
- Add more titles to titles list. Also reorder titles alphabetically and update NEX versions of 3DS titles
- Add `RankingLegacy.GetTotal`
  - Found in Angry Birds Trilogy for the 3DS.