### PR TITLE
NEX version checks update

### DIFF
--- a/build_games_list.js
+++ b/build_games_list.js
@@ -24,11 +24,7 @@ const titles = [
 	{
 		name: 'Friends',
 		access_key: 'ridfebb9',
-		nex_version: { // NEX version doesn't matter here
-			major: 0,
-			minor: 0,
-			patch: 0
-		}
+		nex_version: '1.0.0'
 	}
 ];
 
@@ -43,11 +39,7 @@ for (const line of nexLines) {
 	titles.push({
 		name: name.trim(),
 		access_key: '',
-		nex_version: {
-			major: Number(major),
-			minor: Number(minor),
-			patch: Number(patch)
-		}
+		nex_version: `${major}.${minor}.${patch}`
 	});
 }
 
@@ -62,25 +54,13 @@ for (const line of nexRankingLines) {
 	const game = titles.find(game => game.name === name.trim());
 
 	if (game) {
-		game.nex_ranking_version = {
-			major: Number(major),
-			minor: Number(minor),
-			patch: Number(patch)
-		};
+		game.nex_ranking_version = `${major}.${minor}.${patch}`;
 	} else {
 		titles.push({
 			name: name.trim(),
 			access_key: '',
-			nex_version: {
-				major: 0,
-				minor: 0,
-				patch: 0
-			},
-			nex_ranking_version: {
-				major: Number(major),
-				minor: Number(minor),
-				patch: Number(patch)
-			}
+			nex_version: '0.0.0',
+			nex_ranking_version: `${major}.${minor}.${patch}`
 		});
 	}
 }
@@ -96,25 +76,13 @@ for (const line of nexDataStoreLines) {
 	const game = titles.find(game => game.name === name.trim());
 
 	if (game) {
-		game.nex_datastore_version = {
-			major: Number(major),
-			minor: Number(minor),
-			patch: Number(patch)
-		};
+		game.nex_datastore_version = `${major}.${minor}.${patch}`;
 	} else {
 		titles.push({
 			name: name.trim(),
 			access_key: '',
-			nex_version: {
-				major: 0,
-				minor: 0,
-				patch: 0
-			},
-			nex_datastore_version: {
-				major: Number(major),
-				minor: Number(minor),
-				patch: Number(patch)
-			}
+			nex_version: '0.0.0',
+			nex_datastore_version: `${major}.${minor}.${patch}`
 		});
 	}
 }
@@ -130,25 +98,13 @@ for (const line of nexMatchMakingLines) {
 	const game = titles.find(game => game.name === name.trim());
 
 	if (game) {
-		game.nex_match_making_version = {
-			major: Number(major),
-			minor: Number(minor),
-			patch: Number(patch)
-		};
+		game.nex_match_making_version = `${major}.${minor}.${patch}`;
 	} else {
 		titles.push({
 			name: name.trim(),
 			access_key: '',
-			nex_version: {
-				major: 0,
-				minor: 0,
-				patch: 0
-			},
-			nex_match_making_version: {
-				major: Number(major),
-				minor: Number(minor),
-				patch: Number(patch)
-			}
+			nex_version: '0.0.0',
+			nex_match_making_version: `${major}.${minor}.${patch}`
 		});
 	}
 }
@@ -164,25 +120,13 @@ for (const line of nexMessagingLines) {
 	const game = titles.find(game => game.name === name.trim());
 
 	if (game) {
-		game.nex_messaging_version = {
-			major: Number(major),
-			minor: Number(minor),
-			patch: Number(patch)
-		};
+		game.nex_messaging_version = `${major}.${minor}.${patch}`;
 	} else {
 		titles.push({
 			name: name.trim(),
 			access_key: '',
-			nex_version: {
-				major: 0,
-				minor: 0,
-				patch: 0
-			},
-			nex_messaging_version: {
-				major: Number(major),
-				minor: Number(minor),
-				patch: Number(patch)
-			}
+			nex_version: '0.0.0',
+			nex_messaging_version: `${major}.${minor}.${patch}`
 		});
 	}
 }
@@ -198,25 +142,13 @@ for (const line of nexUtilityLines) {
 	const game = titles.find(game => game.name === name.trim());
 
 	if (game) {
-		game.nex_utility_version = {
-			major: Number(major),
-			minor: Number(minor),
-			patch: Number(patch)
-		};
+		game.nex_utility_version = `${major}.${minor}.${patch}`;
 	} else {
 		titles.push({
 			name: name.trim(),
 			access_key: '',
-			nex_version: {
-				major: 0,
-				minor: 0,
-				patch: 0
-			},
-			nex_utility_version: {
-				major: Number(major),
-				minor: Number(minor),
-				patch: Number(patch)
-			}
+			nex_version: '0.0.0',
+			nex_utility_version: `${major}.${minor}.${patch}`
 		});
 	}
 }
@@ -236,11 +168,7 @@ for (const line of accessLines) {
 		titles.push({
 			name: name.trim(),
 			access_key: accessKey.trim(),
-			nex_version: {
-				major: 0,
-				minor: 0,
-				patch: 0
-			}
+			nex_version: '0.0.0'
 		});
 	}
 }

--- a/nex/nex_datastore.txt
+++ b/nex/nex_datastore.txt
@@ -1,0 +1,70 @@
+Angry Birds Star Wars 3DS    | 3.2.1
+Angry Birds Trilogy 3DS      | 2.7.2
+Animal Crossing: New Leaf    | 3.10.1
+Animal Crossing Plaza        | 3.5.1
+Axiom Verge                  | 3.10.0
+Badge Arcade                 | 3.7.3
+BIOHAZARD REVELATIONS UE     | 3.2.1
+Devil's Third                | 3.6.1
+Disney INFINITY              | 3.5.2
+Disney Infinity [2.0]        | 3.5.2
+DISNEY INFINITY 3.0          | 3.9.1
+DKC: Tropical Freeze         | 3.4.0
+DuckTales: Remastered        | 3.3.0
+FAST Racing NEO              | 3.9.1
+FotNS: Ken's Rage 2          | 3.0.1
+Game Party                   | 3.0.1
+Hyrule Warriors              | 3.8.0
+Injustice: Gods Among Us     | 3.2.1
+IRONFALL Invasion            | 3.7.1
+Legend of Kay                | 3.8.3
+LOST REAVERS                 | 3.10.0
+Mario & Sonic Rio 2016 3DS   | 3.9.1
+Mario & Sonic Rio 2016 Wii U | 3.9.1
+MARIO & SONIC SOCHI 2014     | 3.4.0
+MARIO KART 7                 | 2.4.3
+MARIO KART 8                 | 3.5.4
+Mario Tennis Open            | 2.6.1
+Mario Tennis: Ultra Smash    | 3.9.1
+Mario vs. DK: Tipping Stars  | 3.7.1
+Metroid Prime: FF            | 3.9.1
+MH3G HD Ver.                 | 3.0.5
+MH3U                         | 3.0.5
+Mighty No. 9                 | 3.9.1
+Minecraft: Wii U Edition     | 3.10.0
+Nano Assault Neo             | 3.0.1
+NINJA GAIDEN 3: Razor's Edge | 3.0.1
+Nova-111                     | 3.8.3
+OlliOlli                     | 3.6.1
+PIKMIN 3                     | 3.3.0
+Pokémon Bank                 | 3.4.12
+Pokémon Rumble World         | 3.8.2
+POKKÉN TOURNAMENT            | 3.10.0
+Puddle                       | 3.0.1
+PUYOPUYOTETRIS               | 3.5.2
+RESIDENT EVIL REVELATIONS    | 3.2.1
+RTK 12                       | 3.4.0
+Runner2                      | 3.0.1
+SI2                          | 3.6.1
+SONIC LOST WORLD             | 3.3.0
+Sonic Transformed            | 3.0.1
+Splatoon                     | 3.8.3
+Star Fox Guard               | 3.8.2
+Star Fox Guard (Demo)        | 3.8.2
+Star Wars Pinball            | 3.0.1
+Steel Diver: Sub Wars        | 3.7.0
+Super Mario Maker            | 3.8.12
+Super Smash Bros.            | 3.6.27
+Team Kirby Clash Deluxe      | 3.10.1
+TEKKEN TAG 2 Wii U EDITION   | 3.0.1
+Terraria                     | 3.8.3
+Trine 2                      | 3.0.1
+WARRIORS OROCHI 3 Hyper      | 3.0.1
+Wii Karaoke U                | 3.4.0
+Wii Party U                  | 3.3.0
+Wii Sports Club              | 3.4.7
+Xenoblade Chronicles X       | 3.5.5
+XenobladeX                   | 3.5.5
+Yo-kai Watch 2               | 3.6.1
+Zen Pinball 2                | 3.0.1
+役満 鳳凰                    | 3.6.14

--- a/nex/nex_match_making.txt
+++ b/nex/nex_match_making.txt
@@ -1,0 +1,70 @@
+Angry Birds Star Wars 3DS    | 3.2.1
+Angry Birds Trilogy 3DS      | 2.7.2
+Animal Crossing: New Leaf    | 3.10.1
+Animal Crossing Plaza        | 3.5.1
+Axiom Verge                  | 3.10.0
+Badge Arcade                 | 3.7.3
+BIOHAZARD REVELATIONS UE     | 3.2.1
+Devil's Third                | 3.6.1
+Disney INFINITY              | 3.5.2
+Disney Infinity [2.0]        | 3.5.2
+DISNEY INFINITY 3.0          | 3.9.1
+DKC: Tropical Freeze         | 3.4.0
+DuckTales: Remastered        | 3.3.0
+FAST Racing NEO              | 3.9.1
+FotNS: Ken's Rage 2          | 3.0.1
+Game Party                   | 3.0.1
+Hyrule Warriors              | 3.8.0
+Injustice: Gods Among Us     | 3.2.1
+IRONFALL Invasion            | 3.7.1
+Legend of Kay                | 3.8.3
+LOST REAVERS                 | 3.10.0
+Mario & Sonic Rio 2016 3DS   | 3.9.1
+Mario & Sonic Rio 2016 Wii U | 3.9.1
+MARIO & SONIC SOCHI 2014     | 3.4.0
+MARIO KART 7                 | 2.4.3
+MARIO KART 8                 | 3.5.4
+Mario Tennis Open            | 2.6.1
+Mario Tennis: Ultra Smash    | 3.9.1
+Mario vs. DK: Tipping Stars  | 3.7.1
+Metroid Prime: FF            | 3.9.1
+MH3G HD Ver.                 | 3.0.5
+MH3U                         | 3.0.5
+Mighty No. 9                 | 3.9.1
+Minecraft: Wii U Edition     | 3.10.0
+Nano Assault Neo             | 3.0.1
+NINJA GAIDEN 3: Razor's Edge | 3.0.1
+Nova-111                     | 3.8.3
+OlliOlli                     | 3.6.1
+PIKMIN 3                     | 3.3.0
+Pokémon Bank                 | 3.4.12
+Pokémon Rumble World         | 3.8.2
+POKKÉN TOURNAMENT            | 3.10.0
+Puddle                       | 3.0.1
+PUYOPUYOTETRIS               | 3.5.2
+RESIDENT EVIL REVELATIONS    | 3.2.1
+RTK 12                       | 3.4.0
+Runner2                      | 3.0.1
+SI2                          | 3.6.1
+SONIC LOST WORLD             | 3.3.0
+Sonic Transformed            | 3.0.1
+Splatoon                     | 3.8.3
+Star Fox Guard               | 3.8.2
+Star Fox Guard (Demo)        | 3.8.2
+Star Wars Pinball            | 3.0.1
+Steel Diver: Sub Wars        | 3.7.0
+Super Mario Maker            | 3.8.12
+Super Smash Bros.            | 3.6.27
+Team Kirby Clash Deluxe      | 3.10.1
+TEKKEN TAG 2 Wii U EDITION   | 3.0.1
+Terraria                     | 3.8.3
+Trine 2                      | 3.0.1
+WARRIORS OROCHI 3 Hyper      | 3.0.1
+Wii Karaoke U                | 3.4.0
+Wii Party U                  | 3.3.0
+Wii Sports Club              | 3.4.7
+Xenoblade Chronicles X       | 3.5.5
+XenobladeX                   | 3.5.5
+Yo-kai Watch 2               | 3.6.1
+Zen Pinball 2                | 3.0.1
+役満 鳳凰                    | 3.6.14

--- a/nex/nex_messaging.txt
+++ b/nex/nex_messaging.txt
@@ -1,0 +1,70 @@
+Angry Birds Star Wars 3DS    | 3.2.1
+Angry Birds Trilogy 3DS      | 2.7.2
+Animal Crossing: New Leaf    | 3.10.1
+Animal Crossing Plaza        | 3.5.1
+Axiom Verge                  | 3.10.0
+Badge Arcade                 | 3.7.3
+BIOHAZARD REVELATIONS UE     | 3.2.1
+Devil's Third                | 3.6.1
+Disney INFINITY              | 3.5.2
+Disney Infinity [2.0]        | 3.5.2
+DISNEY INFINITY 3.0          | 3.9.1
+DKC: Tropical Freeze         | 3.4.0
+DuckTales: Remastered        | 3.3.0
+FAST Racing NEO              | 3.9.1
+FotNS: Ken's Rage 2          | 3.0.1
+Game Party                   | 3.0.1
+Hyrule Warriors              | 3.8.0
+Injustice: Gods Among Us     | 3.2.1
+IRONFALL Invasion            | 3.7.1
+Legend of Kay                | 3.8.3
+LOST REAVERS                 | 3.10.0
+Mario & Sonic Rio 2016 3DS   | 3.9.1
+Mario & Sonic Rio 2016 Wii U | 3.9.1
+MARIO & SONIC SOCHI 2014     | 3.4.0
+MARIO KART 7                 | 2.4.3
+MARIO KART 8                 | 3.5.4
+Mario Tennis Open            | 2.6.1
+Mario Tennis: Ultra Smash    | 3.9.1
+Mario vs. DK: Tipping Stars  | 3.7.1
+Metroid Prime: FF            | 3.9.1
+MH3G HD Ver.                 | 3.0.5
+MH3U                         | 3.0.5
+Mighty No. 9                 | 3.9.1
+Minecraft: Wii U Edition     | 3.10.0
+Nano Assault Neo             | 3.0.1
+NINJA GAIDEN 3: Razor's Edge | 3.0.1
+Nova-111                     | 3.8.3
+OlliOlli                     | 3.6.1
+PIKMIN 3                     | 3.3.0
+Pokémon Bank                 | 3.4.12
+Pokémon Rumble World         | 3.8.2
+POKKÉN TOURNAMENT            | 3.10.0
+Puddle                       | 3.0.1
+PUYOPUYOTETRIS               | 3.5.2
+RESIDENT EVIL REVELATIONS    | 3.2.1
+RTK 12                       | 3.4.0
+Runner2                      | 3.0.1
+SI2                          | 3.6.1
+SONIC LOST WORLD             | 3.3.0
+Sonic Transformed            | 3.0.1
+Splatoon                     | 3.8.3
+Star Fox Guard               | 3.8.2
+Star Fox Guard (Demo)        | 3.8.2
+Star Wars Pinball            | 3.0.1
+Steel Diver: Sub Wars        | 3.7.0
+Super Mario Maker            | 3.8.12
+Super Smash Bros.            | 3.6.27
+Team Kirby Clash Deluxe      | 3.10.1
+TEKKEN TAG 2 Wii U EDITION   | 3.0.1
+Terraria                     | 3.8.3
+Trine 2                      | 3.0.1
+WARRIORS OROCHI 3 Hyper      | 3.0.1
+Wii Karaoke U                | 3.4.0
+Wii Party U                  | 3.3.0
+Wii Sports Club              | 3.4.7
+Xenoblade Chronicles X       | 3.5.5
+XenobladeX                   | 3.5.5
+Yo-kai Watch 2               | 3.6.1
+Zen Pinball 2                | 3.0.1
+役満 鳳凰                    | 3.6.14

--- a/nex/nex_ranking.txt
+++ b/nex/nex_ranking.txt
@@ -1,0 +1,70 @@
+Angry Birds Star Wars 3DS    | 3.2.1
+Angry Birds Trilogy 3DS      | 2.7.2
+Animal Crossing: New Leaf    | 3.10.1
+Animal Crossing Plaza        | 3.5.1
+Axiom Verge                  | 3.10.0
+Badge Arcade                 | 3.7.3
+BIOHAZARD REVELATIONS UE     | 3.2.1
+Devil's Third                | 3.6.1
+Disney INFINITY              | 3.5.2
+Disney Infinity [2.0]        | 3.5.2
+DISNEY INFINITY 3.0          | 3.9.1
+DKC: Tropical Freeze         | 3.4.0
+DuckTales: Remastered        | 3.3.0
+FAST Racing NEO              | 3.9.1
+FotNS: Ken's Rage 2          | 3.0.1
+Game Party                   | 3.0.1
+Hyrule Warriors              | 3.8.0
+Injustice: Gods Among Us     | 3.2.1
+IRONFALL Invasion            | 3.7.1
+Legend of Kay                | 3.8.3
+LOST REAVERS                 | 3.10.0
+Mario & Sonic Rio 2016 3DS   | 3.9.1
+Mario & Sonic Rio 2016 Wii U | 3.9.1
+MARIO & SONIC SOCHI 2014     | 3.4.0
+MARIO KART 7                 | 2.4.3
+MARIO KART 8                 | 3.5.4
+Mario Tennis Open            | 2.6.1
+Mario Tennis: Ultra Smash    | 3.9.1
+Mario vs. DK: Tipping Stars  | 3.7.1
+Metroid Prime: FF            | 3.9.1
+MH3G HD Ver.                 | 3.0.5
+MH3U                         | 3.0.5
+Mighty No. 9                 | 3.9.1
+Minecraft: Wii U Edition     | 3.10.0
+Nano Assault Neo             | 3.0.1
+NINJA GAIDEN 3: Razor's Edge | 3.0.1
+Nova-111                     | 3.8.3
+OlliOlli                     | 3.6.1
+PIKMIN 3                     | 3.3.0
+Pokémon Bank                 | 3.4.12
+Pokémon Rumble World         | 3.8.2
+POKKÉN TOURNAMENT            | 3.10.0
+Puddle                       | 3.0.1
+PUYOPUYOTETRIS               | 3.5.2
+RESIDENT EVIL REVELATIONS    | 3.2.1
+RTK 12                       | 3.4.0
+Runner2                      | 3.0.1
+SI2                          | 3.6.1
+SONIC LOST WORLD             | 3.3.0
+Sonic Transformed            | 3.0.1
+Splatoon                     | 3.8.3
+Star Fox Guard               | 3.8.2
+Star Fox Guard (Demo)        | 3.8.2
+Star Wars Pinball            | 3.0.1
+Steel Diver: Sub Wars        | 3.7.0
+Super Mario Maker            | 3.8.12
+Super Smash Bros.            | 3.6.27
+Team Kirby Clash Deluxe      | 3.10.1
+TEKKEN TAG 2 Wii U EDITION   | 3.0.1
+Terraria                     | 3.8.3
+Trine 2                      | 3.0.1
+WARRIORS OROCHI 3 Hyper      | 3.0.1
+Wii Karaoke U                | 3.4.0
+Wii Party U                  | 3.3.0
+Wii Sports Club              | 3.4.7
+Xenoblade Chronicles X       | 3.5.5
+XenobladeX                   | 3.5.5
+Yo-kai Watch 2               | 3.6.1
+Zen Pinball 2                | 3.0.1
+役満 鳳凰                    | 3.6.14

--- a/nex/nex_utility.txt
+++ b/nex/nex_utility.txt
@@ -1,0 +1,70 @@
+Angry Birds Star Wars 3DS    | 3.2.1
+Angry Birds Trilogy 3DS      | 2.7.2
+Animal Crossing: New Leaf    | 3.10.1
+Animal Crossing Plaza        | 3.5.1
+Axiom Verge                  | 3.10.0
+Badge Arcade                 | 3.7.3
+BIOHAZARD REVELATIONS UE     | 3.2.1
+Devil's Third                | 3.6.1
+Disney INFINITY              | 3.5.2
+Disney Infinity [2.0]        | 3.5.2
+DISNEY INFINITY 3.0          | 3.9.1
+DKC: Tropical Freeze         | 3.4.0
+DuckTales: Remastered        | 3.3.0
+FAST Racing NEO              | 3.9.1
+FotNS: Ken's Rage 2          | 3.0.1
+Game Party                   | 3.0.1
+Hyrule Warriors              | 3.8.0
+Injustice: Gods Among Us     | 3.2.1
+IRONFALL Invasion            | 3.7.1
+Legend of Kay                | 3.8.3
+LOST REAVERS                 | 3.10.0
+Mario & Sonic Rio 2016 3DS   | 3.9.1
+Mario & Sonic Rio 2016 Wii U | 3.9.1
+MARIO & SONIC SOCHI 2014     | 3.4.0
+MARIO KART 7                 | 2.4.3
+MARIO KART 8                 | 3.5.4
+Mario Tennis Open            | 2.6.1
+Mario Tennis: Ultra Smash    | 3.9.1
+Mario vs. DK: Tipping Stars  | 3.7.1
+Metroid Prime: FF            | 3.9.1
+MH3G HD Ver.                 | 3.0.5
+MH3U                         | 3.0.5
+Mighty No. 9                 | 3.9.1
+Minecraft: Wii U Edition     | 3.10.0
+Nano Assault Neo             | 3.0.1
+NINJA GAIDEN 3: Razor's Edge | 3.0.1
+Nova-111                     | 3.8.3
+OlliOlli                     | 3.6.1
+PIKMIN 3                     | 3.3.0
+Pokémon Bank                 | 3.4.12
+Pokémon Rumble World         | 3.8.2
+POKKÉN TOURNAMENT            | 3.10.0
+Puddle                       | 3.0.1
+PUYOPUYOTETRIS               | 3.5.2
+RESIDENT EVIL REVELATIONS    | 3.2.1
+RTK 12                       | 3.4.0
+Runner2                      | 3.0.1
+SI2                          | 3.6.1
+SONIC LOST WORLD             | 3.3.0
+Sonic Transformed            | 3.0.1
+Splatoon                     | 3.8.3
+Star Fox Guard               | 3.8.2
+Star Fox Guard (Demo)        | 3.8.2
+Star Wars Pinball            | 3.0.1
+Steel Diver: Sub Wars        | 3.7.0
+Super Mario Maker            | 3.8.12
+Super Smash Bros.            | 3.6.27
+Team Kirby Clash Deluxe      | 3.10.1
+TEKKEN TAG 2 Wii U EDITION   | 3.0.1
+Terraria                     | 3.8.3
+Trine 2                      | 3.0.1
+WARRIORS OROCHI 3 Hyper      | 3.0.1
+Wii Karaoke U                | 3.4.0
+Wii Party U                  | 3.3.0
+Wii Sports Club              | 3.4.7
+Xenoblade Chronicles X       | 3.5.5
+XenobladeX                   | 3.5.5
+Yo-kai Watch 2               | 3.6.1
+Zen Pinball 2                | 3.0.1
+役満 鳳凰                    | 3.6.14

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "pcap-ng-parser": "^1.0.0",
         "pcap-parser": "^0.2.1",
-        "private-ip": "^2.3.4"
+        "private-ip": "^2.3.4",
+        "semver": "^7.5.4"
       },
       "devDependencies": {
         "electron": "^21.2.0",
@@ -2715,7 +2716,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3320,10 +3320,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3838,8 +3837,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.6.2",
@@ -5979,7 +5977,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -6411,10 +6408,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -6809,8 +6805,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "17.6.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "pcap-ng-parser": "^1.0.0",
     "pcap-parser": "^0.2.1",
-    "private-ip": "^2.3.4"
+    "private-ip": "^2.3.4",
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "electron": "^21.2.0",

--- a/src/connection.js
+++ b/src/connection.js
@@ -107,11 +107,13 @@ class Connection {
 
 		this.title = {
 			name: '',
-			nex_version: {
-				major: 0,
-				minor: 0,
-				patch: 0
-			}
+			access_key: '',
+			nex_version: '0.0.0',
+			nex_ranking_version: '0.0.0',
+			nex_datastore_version: '0.0.0',
+			nex_match_making_version: '0.0.0',
+			nex_messaging_version: '0.0.0',
+			nex_utility_version: '0.0.0'
 		};
 
 		this.clientFragmentationManager = new FragmentationManager();

--- a/src/protocols/ranking.js
+++ b/src/protocols/ranking.js
@@ -75,7 +75,7 @@ class Ranking {
 
 		// Check if game uses legacy Ranking. Since there aren't many games that use it,
 		// assume games not listed on title list to use modern Ranking
-		if (semver.lt(nexVersion, '3.0.0')) {
+		if (semver.lt(nexVersion, '3.0.0') && semver.gt(nexVersion, '0.0.0')) {
 			RankingLegacy.handlePacket(packet);
 			return;
 		}

--- a/src/protocols/ranking.js
+++ b/src/protocols/ranking.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Packet = require('../packet'); // eslint-disable-line no-unused-vars
 const PacketV0 = require('../packetv0'); // eslint-disable-line no-unused-vars
 const PacketV1 = require('../packetv1'); // eslint-disable-line no-unused-vars
@@ -70,16 +71,11 @@ class Ranking {
 			return;
 		}
 
-		let nexVersion;
-		if (packet.connection.title.nex_ranking_version) {
-			nexVersion = packet.connection.title.nex_ranking_version;
-		} else {
-			nexVersion = packet.connection.title.nex_version;
-		}
+		const nexVersion = packet.connection.title.nex_ranking_version || packet.connection.title.nex_version;
 
 		// Check if game uses legacy Ranking. Since there aren't many games that use it,
 		// assume games not listed on title list to use modern Ranking
-		if (nexVersion.major < 3 && nexVersion.major > 0) {
+		if (semver.lt(nexVersion, '3.0.0')) {
 			RankingLegacy.handlePacket(packet);
 			return;
 		}

--- a/src/protocols/requests/datastore.js
+++ b/src/protocols/requests/datastore.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Stream = require('../../stream'); // eslint-disable-line no-unused-vars
 const DataStoreTypes = require('../types/datastore');
 
@@ -278,17 +279,12 @@ class RateObjectRequest {
 	 * @param {Stream} stream NEX data stream
 	 */
 	constructor(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_datastore_version) {
-			nexVersion = stream.connection.title.nex_datastore_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_datastore_version || stream.connection.title.nex_version;
 
 		this.target = stream.readNEXStructure(DataStoreTypes.DataStoreRatingTarget);
 		this.param = stream.readNEXStructure(DataStoreTypes.DataStoreRateObjectParam);
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.fetchRatings = stream.readBoolean();
 		}
 	}

--- a/src/protocols/requests/matchmake_extension.js
+++ b/src/protocols/requests/matchmake_extension.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Stream = require('../../stream'); // eslint-disable-line no-unused-vars
 const NEXTypes = require('../../types');
 const MatchMakingTypes = require('../types/match_making');
@@ -112,17 +113,12 @@ class CreateMatchmakeSessionRequest {
 	 * @param {Stream} stream NEX data stream
 	 */
 	constructor(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_match_making_version) {
-			nexVersion = stream.connection.title.nex_match_making_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_match_making_version || stream.connection.title.nex_version;
 
 		this.anyGathering = stream.readNEXAnyDataHolder();
 		this.strMessage = stream.readNEXString();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.participationCount = stream.readUInt16LE();
 		}
 	}

--- a/src/protocols/responses/matchmake_extension.js
+++ b/src/protocols/responses/matchmake_extension.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Stream = require('../../stream'); // eslint-disable-line no-unused-vars
 const MatchMakingTypes = require('../types/match_making');
 const NotificationsTypes = require('../types/notifications');
@@ -80,16 +81,11 @@ class CreateMatchmakeSessionResponse {
 	 * @param {Stream} stream NEX data stream
 	 */
 	constructor(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_match_making_version) {
-			nexVersion = stream.connection.title.nex_match_making_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_match_making_version || stream.connection.title.nex_version;
 
 		this.gid = stream.readUInt32LE();
 
-		if (nexVersion.major >= 3) {
+		if (semver.gte(nexVersion, '3.0.0')) {
 			this.sessionKey = stream.readNEXBuffer();
 		}
 	}
@@ -118,14 +114,9 @@ class JoinMatchmakeSessionResponse {
 	 * @param {Stream} stream NEX data stream
 	 */
 	constructor(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_match_making_version) {
-			nexVersion = stream.connection.title.nex_match_making_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_match_making_version || stream.connection.title.nex_version;
 
-		if (nexVersion.major >= 3) {
+		if (semver.gte(nexVersion, '3.0.0')) {
 			this.sessionKey = stream.readNEXBuffer();
 		}
 	}

--- a/src/protocols/types/datastore.js
+++ b/src/protocols/types/datastore.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Stream = require('../../stream'); // eslint-disable-line no-unused-vars
 const NEXTypes = require('../../types');
 
@@ -230,19 +231,14 @@ class DataStoreReqGetInfo extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_datastore_version) {
-			nexVersion = stream.connection.title.nex_datastore_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_datastore_version || stream.connection.title.nex_version;
 
 		this.url = stream.readNEXString();
 		this.requestHeaders = stream.readNEXList(DataStoreKeyValue);
 		this.size = stream.readUInt32LE();
 		this.rootCaCert = stream.readNEXBuffer();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.dataId = stream.readUInt64LE();
 		}
 	}
@@ -801,14 +797,9 @@ class DataStorePrepareUpdateParam extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_datastore_version) {
-			nexVersion = stream.connection.title.nex_datastore_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_datastore_version || stream.connection.title.nex_version;
 
-		if (nexVersion.major >= 3) {
+		if (semver.gte(nexVersion, '3.0.0')) {
 			this.dataId = stream.readUInt64LE();
 
 			// * Hack to get the proper type when encoding to JSON
@@ -820,11 +811,11 @@ class DataStorePrepareUpdateParam extends NEXTypes.Structure {
 
 		this.size = stream.readUInt32LE();
 
-		if (nexVersion.major >= 3) {
+		if (semver.gte(nexVersion, '3.0.0')) {
 			this.updatePassword = stream.readUInt64LE();
 		}
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.extraData = stream.readNEXList(stream.readNEXString);
 		}
 	}
@@ -868,14 +859,9 @@ class DataStoreReqUpdateInfo extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_datastore_version) {
-			nexVersion = stream.connection.title.nex_datastore_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_datastore_version || stream.connection.title.nex_version;
 
-		if (nexVersion.major >= 3) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.version = stream.readUInt32LE();
 
 			// * Hack to get the proper type when encoding to JSON
@@ -927,14 +913,9 @@ class DataStoreCompleteUpdateParam extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_datastore_version) {
-			nexVersion = stream.connection.title.nex_datastore_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_datastore_version || stream.connection.title.nex_version;
 
-		if (nexVersion.major >= 3) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.dataId = stream.readUInt64LE();
 
 			// * Hack to get the proper type when encoding to JSON
@@ -944,7 +925,7 @@ class DataStoreCompleteUpdateParam extends NEXTypes.Structure {
 			this.#dataIdType = 'uint32';
 		}
 
-		if (nexVersion.major >= 3) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.version = stream.readUInt32LE();
 			this.#versionType = 'uint32';
 		} else {
@@ -1516,19 +1497,14 @@ class DataStorePrepareGetParam extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_datastore_version) {
-			nexVersion = stream.connection.title.nex_datastore_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_datastore_version || stream.connection.title.nex_version;
 
 		this.dataId = stream.readUInt64LE();
 		this.lockId = stream.readUInt32LE();
 		this.persistenceTarget = stream.readNEXStructure(DataStorePersistenceTarget);
 		this.accessPassword = stream.readUInt64LE();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.extraData = stream.readNEXList(stream.readNEXString);
 		}
 	}
@@ -1571,12 +1547,7 @@ class DataStorePreparePostParam extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_datastore_version) {
-			nexVersion = stream.connection.title.nex_datastore_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_datastore_version || stream.connection.title.nex_version;
 
 		this.size = stream.readUInt32LE();
 		this.name = stream.readNEXString();
@@ -1591,7 +1562,7 @@ class DataStorePreparePostParam extends NEXTypes.Structure {
 		this.ratingInitParams = stream.readNEXList(DataStoreRatingInitParamWithSlot);
 		this.persistenceInitParam = stream.readNEXStructure(DataStorePersistenceInitParam);
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.extraData = stream.readNEXList(stream.readNEXString);
 		}
 	}

--- a/src/protocols/types/match_making.js
+++ b/src/protocols/types/match_making.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Stream = require('../../stream'); // eslint-disable-line no-unused-vars
 const NEXTypes = require('../../types');
 
@@ -144,12 +145,7 @@ class MatchmakeSession extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_match_making_version) {
-			nexVersion = stream.connection.title.nex_match_making_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_match_making_version || stream.connection.title.nex_version;
 
 		this.m_GameMode = stream.readUInt32LE();
 		this.m_Attribs = stream.readNEXList(stream.readUInt32LE);
@@ -158,34 +154,34 @@ class MatchmakeSession extends NEXTypes.Structure {
 		this.m_ApplicationBuffer = stream.readNEXBuffer();
 		this.m_ParticipationCount = stream.readUInt32LE();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 4) {
+		if (semver.gte(nexVersion, '3.4.0')) {
 			this.m_ProgressScore = stream.readUInt8();
 		}
 
-		if (nexVersion.major >= 3) {
+		if (semver.gte(nexVersion, '3.0.0')) {
 			this.m_SessionKey = stream.readNEXBuffer();
 		}
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 5) {
+		if (semver.gte(nexVersion, '3.5.0')) {
 			this.m_Option0 = stream.readUInt32LE();
 		}
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 6) {
+		if (semver.gte(nexVersion, '3.6.0')) {
 			this.m_MatchmakeParam = stream.readNEXStructure(MatchmakeParam);
 			this.m_StartedTime = stream.readNEXDateTime();
 		}
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 7) {
+		if (semver.gte(nexVersion, '3.7.0')) {
 			this.m_UserPassword = stream.readNEXString();
 		}
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 8) {
+		if (semver.gte(nexVersion, '3.8.0')) {
 			this.m_ReferGid = stream.readUInt32LE();
 			this.m_UserPasswordEnabled = stream.readBoolean();
 			this.m_SystemPasswordEnabled = stream.readBoolean();
 		}
 
-		if (nexVersion.major >= 4) {
+		if (semver.gte(nexVersion, '4.0.0')) {
 			this.m_Codeword = stream.readNEXString();
 		}
 	}
@@ -304,12 +300,7 @@ class MatchmakeSessionSearchCriteria extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_match_making_version) {
-			nexVersion = stream.connection.title.nex_match_making_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_match_making_version || stream.connection.title.nex_version;
 
 		this.m_Attribs = stream.readNEXList(stream.readNEXString);
 		this.m_GameMode = stream.readNEXString();
@@ -320,28 +311,28 @@ class MatchmakeSessionSearchCriteria extends NEXTypes.Structure {
 		this.m_ExcludeLocked = stream.readBoolean();
 		this.m_ExcludeNonHostPid = stream.readBoolean();
 
-		if (nexVersion.major >= 3) {
+		if (semver.gte(nexVersion, '3.0.0')) {
 			this.m_SelectionMethod = stream.readUInt32LE();
 		}
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 4) {
+		if (semver.gte(nexVersion, '3.4.0')) {
 			this.m_VacantParticipants = stream.readUInt16LE();
 		}
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 6) {
+		if (semver.gte(nexVersion, '3.6.0')) {
 			this.m_MatchmakeParam = stream.readNEXStructure(MatchmakeParam);
 		}
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 7) {
+		if (semver.gte(nexVersion, '3.7.0')) {
 			this.m_ExcludeUserPasswordSet = stream.readBoolean();
 			this.m_ExcludeSystemPasswordSet = stream.readBoolean();
 		}
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 8) {
+		if (semver.gte(nexVersion, '3.8.0')) {
 			this.m_ReferGid = stream.readUInt32LE();
 		}
 
-		if (nexVersion.major >= 4) {
+		if (semver.gte(nexVersion, '4.0.0')) {
 			this.m_Codeword = stream.readNEXString();
 			this.m_ResultRange = stream.readNEXStructure(NEXTypes.ResultRange);
 		}
@@ -713,12 +704,7 @@ class AutoMatchmakeParam extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_match_making_version) {
-			nexVersion = stream.connection.title.nex_match_making_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_match_making_version || stream.connection.title.nex_version;
 
 		this.sourceMatchmakeSession = stream.readNEXStructure(MatchmakeSession);
 		this.additionalParticipants = stream.readNEXList(stream.readPID);
@@ -729,7 +715,7 @@ class AutoMatchmakeParam extends NEXTypes.Structure {
 		this.lstSearchCriteria = stream.readNEXList(MatchmakeSessionSearchCriteria);
 		this.targetGids = stream.readNEXList(stream.readUInt32LE);
 
-		if (nexVersion.major >= 4) {
+		if (semver.gte(nexVersion, '4.0.0')) {
 			this.blockListParam = stream.readNEXStructure(MatchmakeBlockListParam);
 		}
 	}

--- a/src/protocols/types/match_making.js
+++ b/src/protocols/types/match_making.js
@@ -502,6 +502,11 @@ class JoinMatchmakeSessionParam extends NEXTypes.Structure {
 		this.joinMessage = stream.readNEXString();
 		this.participationCount = stream.readUInt16LE();
 
+		// * From Dani:
+		// * - "Just for future reference, Minecraft has structure version 1 on JoinMatchmakeSessionParam"
+		// * These fields COULD be different structure versions, not related to NEX updates.
+		// * Need to do more research
+
 		// * Assuming this to be 3.10.0
 		// * Not seen in Terraria, which is 3.8.3
 		if (semver.gte(nexVersion, '3.10.0')) {

--- a/src/protocols/types/match_making.js
+++ b/src/protocols/types/match_making.js
@@ -946,11 +946,11 @@ class ParticipantDetails extends NEXTypes.Structure {
 			__structureVersion: this._structureHeader.version,
 			m_idParticipant: {
 				__typeName: 'PID',
-				__typeValue: this.m_idGathering
+				__typeValue: this.m_idParticipant
 			},
 			m_strName: {
 				__typeName: 'String',
-				__typeValue: this.m_idGuest
+				__typeValue: this.m_strName
 			},
 			m_strMessage: {
 				__typeName: 'String',
@@ -958,7 +958,7 @@ class ParticipantDetails extends NEXTypes.Structure {
 			},
 			m_uiParticipants: {
 				__typeName: 'uint16',
-				__typeValue: this.m_strMessage
+				__typeValue: this.m_uiParticipants
 			}
 		};
 	}

--- a/src/protocols/types/notifications.js
+++ b/src/protocols/types/notifications.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Stream = require('../../stream'); // eslint-disable-line no-unused-vars
 const NEXTypes = require('../../types');
 
@@ -19,7 +20,7 @@ class NotificationEvent extends NEXTypes.Structure {
 		this.m_uiParam2 = stream.readUInt32LE();
 		this.m_strParam = stream.readNEXString();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 4) {
+		if (semver.gte(nexVersion, '3.4.0')) {
 			this.m_uiParam3 = stream.readUInt32LE();
 		}
 	}

--- a/src/protocols/types/ranking.js
+++ b/src/protocols/types/ranking.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Stream = require('../../stream'); // eslint-disable-line no-unused-vars
 const NEXTypes = require('../../types');
 
@@ -52,12 +53,7 @@ class RankingRankData extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
-		let nexVersion;
-		if (stream.connection.title.nex_ranking_version) {
-			nexVersion = stream.connection.title.nex_ranking_version;
-		} else {
-			nexVersion = stream.connection.title.nex_version;
-		}
+		const nexVersion = stream.connection.title.nex_ranking_version || stream.connection.title.nex_version;
 
 		this.principalId = stream.readPID();
 		this.uniqueId = stream.readUInt64LE();
@@ -68,7 +64,7 @@ class RankingRankData extends NEXTypes.Structure {
 		this.param = stream.readUInt64LE();
 		this.commonData = stream.readNEXBuffer();
 
-		if (nexVersion.major >= 3 && nexVersion.minor >= 6) {
+		if (semver.gte(nexVersion, '3.6.0')) {
 			this.updateTime = stream.readNEXDateTime();
 		}
 	}

--- a/src/protocols/utility.js
+++ b/src/protocols/utility.js
@@ -54,7 +54,7 @@ class Utility {
 
 		// Check if game uses Storage Manager instead of Utility. Since there aren't many games that use it,
 		// assume games not listed on title list to use Utility
-		if (semver.lt(nexVersion, '3.0.0')) {
+		if (semver.lt(nexVersion, '3.0.0') && semver.gt(nexVersion, '0.0.0')) {
 			StorageManager.handlePacket(packet);
 			return;
 		}

--- a/src/protocols/utility.js
+++ b/src/protocols/utility.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Packet = require('../packet'); // eslint-disable-line no-unused-vars
 const PacketV0 = require('../packetv0'); // eslint-disable-line no-unused-vars
 const PacketV1 = require('../packetv1'); // eslint-disable-line no-unused-vars
@@ -49,16 +50,11 @@ class Utility {
 	static handlePacket(packet) {
 		const methodId = packet.rmcMessage.methodId;
 
-		let nexVersion;
-		if (packet.connection.title.nex_utility_version) {
-			nexVersion = packet.connection.title.nex_utility_version;
-		} else {
-			nexVersion = packet.connection.title.nex_version;
-		}
+		const nexVersion = packet.connection.title.nex_utility_version || packet.connection.title.nex_version;
 
 		// Check if game uses Storage Manager instead of Utility. Since there aren't many games that use it,
 		// assume games not listed on title list to use Utility
-		if (nexVersion.major < 3 && nexVersion.major > 0) {
+		if (semver.lt(nexVersion, '3.0.0')) {
 			StorageManager.handlePacket(packet);
 			return;
 		}

--- a/src/titles.json
+++ b/src/titles.json
@@ -2,676 +2,726 @@
     {
         "name": "Friends",
         "access_key": "ridfebb9",
-        "nex_version": {
-            "major": 0,
-            "minor": 0,
-            "patch": 0
-        }
+        "nex_version": "1.0.0"
     },
     {
         "name": "Angry Birds Star Wars 3DS",
         "access_key": "fbae7416",
-        "nex_version": {
-            "major": 3,
-            "minor": 2,
-            "patch": 1
-        }
+        "nex_version": "3.2.1",
+        "nex_ranking_version": "3.2.1",
+        "nex_datastore_version": "3.2.1",
+        "nex_match_making_version": "3.2.1",
+        "nex_messaging_version": "3.2.1",
+        "nex_utility_version": "3.2.1"
     },
     {
         "name": "Angry Birds Trilogy 3DS",
         "access_key": "ac4fbf0d",
-        "nex_version": {
-            "major": 2,
-            "minor": 7,
-            "patch": 2
-        }
+        "nex_version": "2.7.2",
+        "nex_ranking_version": "2.7.2",
+        "nex_datastore_version": "2.7.2",
+        "nex_match_making_version": "2.7.2",
+        "nex_messaging_version": "2.7.2",
+        "nex_utility_version": "2.7.2"
     },
     {
         "name": "Animal Crossing: New Leaf",
         "access_key": "d6f08b40",
-        "nex_version": {
-            "major": 3,
-            "minor": 10,
-            "patch": 1
-        }
+        "nex_version": "3.10.1",
+        "nex_ranking_version": "3.10.1",
+        "nex_datastore_version": "3.10.1",
+        "nex_match_making_version": "3.10.1",
+        "nex_messaging_version": "3.10.1",
+        "nex_utility_version": "3.10.1"
     },
     {
         "name": "Animal Crossing Plaza",
         "access_key": "7b9b09cb",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 1
-        }
+        "nex_version": "3.5.1",
+        "nex_ranking_version": "3.5.1",
+        "nex_datastore_version": "3.5.1",
+        "nex_match_making_version": "3.5.1",
+        "nex_messaging_version": "3.5.1",
+        "nex_utility_version": "3.5.1"
     },
     {
         "name": "Axiom Verge",
         "access_key": "24e0a63b",
-        "nex_version": {
-            "major": 3,
-            "minor": 10,
-            "patch": 0
-        }
+        "nex_version": "3.10.0",
+        "nex_ranking_version": "3.10.0",
+        "nex_datastore_version": "3.10.0",
+        "nex_match_making_version": "3.10.0",
+        "nex_messaging_version": "3.10.0",
+        "nex_utility_version": "3.10.0"
     },
     {
         "name": "Badge Arcade",
         "access_key": "82d5962d",
-        "nex_version": {
-            "major": 3,
-            "minor": 7,
-            "patch": 3
-        }
+        "nex_version": "3.7.3",
+        "nex_ranking_version": "3.7.3",
+        "nex_datastore_version": "3.7.3",
+        "nex_match_making_version": "3.7.3",
+        "nex_messaging_version": "3.7.3",
+        "nex_utility_version": "3.7.3"
     },
     {
         "name": "BIOHAZARD REVELATIONS UE",
         "access_key": "59d539a9",
-        "nex_version": {
-            "major": 3,
-            "minor": 2,
-            "patch": 1
-        }
+        "nex_version": "3.2.1",
+        "nex_ranking_version": "3.2.1",
+        "nex_datastore_version": "3.2.1",
+        "nex_match_making_version": "3.2.1",
+        "nex_messaging_version": "3.2.1",
+        "nex_utility_version": "3.2.1"
     },
     {
         "name": "Devil's Third",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 6,
-            "patch": 1
-        }
+        "nex_version": "3.6.1",
+        "nex_ranking_version": "3.6.1",
+        "nex_datastore_version": "3.6.1",
+        "nex_match_making_version": "3.6.1",
+        "nex_messaging_version": "3.6.1",
+        "nex_utility_version": "3.6.1"
     },
     {
         "name": "Disney INFINITY",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 2
-        }
+        "nex_version": "3.5.2",
+        "nex_ranking_version": "3.5.2",
+        "nex_datastore_version": "3.5.2",
+        "nex_match_making_version": "3.5.2",
+        "nex_messaging_version": "3.5.2",
+        "nex_utility_version": "3.5.2"
     },
     {
         "name": "Disney Infinity [2.0]",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 2
-        }
+        "nex_version": "3.5.2",
+        "nex_ranking_version": "3.5.2",
+        "nex_datastore_version": "3.5.2",
+        "nex_match_making_version": "3.5.2",
+        "nex_messaging_version": "3.5.2",
+        "nex_utility_version": "3.5.2"
     },
     {
         "name": "DISNEY INFINITY 3.0",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 9,
-            "patch": 1
-        }
+        "nex_version": "3.9.1",
+        "nex_ranking_version": "3.9.1",
+        "nex_datastore_version": "3.9.1",
+        "nex_match_making_version": "3.9.1",
+        "nex_messaging_version": "3.9.1",
+        "nex_utility_version": "3.9.1"
     },
     {
         "name": "DKC: Tropical Freeze",
         "access_key": "7fcf384a",
-        "nex_version": {
-            "major": 3,
-            "minor": 4,
-            "patch": 0
-        }
+        "nex_version": "3.4.0",
+        "nex_ranking_version": "3.4.0",
+        "nex_datastore_version": "3.4.0",
+        "nex_match_making_version": "3.4.0",
+        "nex_messaging_version": "3.4.0",
+        "nex_utility_version": "3.4.0"
     },
     {
         "name": "DuckTales: Remastered",
         "access_key": "1294a96c",
-        "nex_version": {
-            "major": 3,
-            "minor": 3,
-            "patch": 0
-        }
+        "nex_version": "3.3.0",
+        "nex_ranking_version": "3.3.0",
+        "nex_datastore_version": "3.3.0",
+        "nex_match_making_version": "3.3.0",
+        "nex_messaging_version": "3.3.0",
+        "nex_utility_version": "3.3.0"
     },
     {
         "name": "FAST Racing NEO",
         "access_key": "811aa39f",
-        "nex_version": {
-            "major": 3,
-            "minor": 9,
-            "patch": 1
-        }
+        "nex_version": "3.9.1",
+        "nex_ranking_version": "3.9.1",
+        "nex_datastore_version": "3.9.1",
+        "nex_match_making_version": "3.9.1",
+        "nex_messaging_version": "3.9.1",
+        "nex_utility_version": "3.9.1"
     },
     {
         "name": "FotNS: Ken's Rage 2",
         "access_key": "9994e29c",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "Game Party",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "Hyrule Warriors",
         "access_key": "7fcc1f7c",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 0
-        }
+        "nex_version": "3.8.0",
+        "nex_ranking_version": "3.8.0",
+        "nex_datastore_version": "3.8.0",
+        "nex_match_making_version": "3.8.0",
+        "nex_messaging_version": "3.8.0",
+        "nex_utility_version": "3.8.0"
     },
     {
         "name": "Injustice: Gods Among Us",
         "access_key": "65e9f4d6",
-        "nex_version": {
-            "major": 3,
-            "minor": 2,
-            "patch": 1
-        }
+        "nex_version": "3.2.1",
+        "nex_ranking_version": "3.2.1",
+        "nex_datastore_version": "3.2.1",
+        "nex_match_making_version": "3.2.1",
+        "nex_messaging_version": "3.2.1",
+        "nex_utility_version": "3.2.1"
     },
     {
         "name": "IRONFALL Invasion",
         "access_key": "feb81c7c",
-        "nex_version": {
-            "major": 3,
-            "minor": 7,
-            "patch": 1
-        }
+        "nex_version": "3.7.1",
+        "nex_ranking_version": "3.7.1",
+        "nex_datastore_version": "3.7.1",
+        "nex_match_making_version": "3.7.1",
+        "nex_messaging_version": "3.7.1",
+        "nex_utility_version": "3.7.1"
     },
     {
         "name": "Legend of Kay",
         "access_key": "478232f3",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 3
-        }
+        "nex_version": "3.8.3",
+        "nex_ranking_version": "3.8.3",
+        "nex_datastore_version": "3.8.3",
+        "nex_match_making_version": "3.8.3",
+        "nex_messaging_version": "3.8.3",
+        "nex_utility_version": "3.8.3"
     },
     {
         "name": "LOST REAVERS",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 10,
-            "patch": 0
-        }
+        "nex_version": "3.10.0",
+        "nex_ranking_version": "3.10.0",
+        "nex_datastore_version": "3.10.0",
+        "nex_match_making_version": "3.10.0",
+        "nex_messaging_version": "3.10.0",
+        "nex_utility_version": "3.10.0"
     },
     {
         "name": "Mario & Sonic Rio 2016 3DS",
         "access_key": "a2dbfa39",
-        "nex_version": {
-            "major": 3,
-            "minor": 9,
-            "patch": 1
-        }
+        "nex_version": "3.9.1",
+        "nex_ranking_version": "3.9.1",
+        "nex_datastore_version": "3.9.1",
+        "nex_match_making_version": "3.9.1",
+        "nex_messaging_version": "3.9.1",
+        "nex_utility_version": "3.9.1"
     },
     {
         "name": "Mario & Sonic Rio 2016 Wii U",
         "access_key": "63fecb0f",
-        "nex_version": {
-            "major": 3,
-            "minor": 9,
-            "patch": 1
-        }
+        "nex_version": "3.9.1",
+        "nex_ranking_version": "3.9.1",
+        "nex_datastore_version": "3.9.1",
+        "nex_match_making_version": "3.9.1",
+        "nex_messaging_version": "3.9.1",
+        "nex_utility_version": "3.9.1"
     },
     {
         "name": "MARIO & SONIC SOCHI 2014",
         "access_key": "585214a5",
-        "nex_version": {
-            "major": 3,
-            "minor": 4,
-            "patch": 0
-        }
+        "nex_version": "3.4.0",
+        "nex_ranking_version": "3.4.0",
+        "nex_datastore_version": "3.4.0",
+        "nex_match_making_version": "3.4.0",
+        "nex_messaging_version": "3.4.0",
+        "nex_utility_version": "3.4.0"
     },
     {
         "name": "MARIO KART 7",
         "access_key": "6181dff1",
-        "nex_version": {
-            "major": 2,
-            "minor": 4,
-            "patch": 3
-        }
+        "nex_version": "2.4.3",
+        "nex_ranking_version": "2.4.3",
+        "nex_datastore_version": "2.4.3",
+        "nex_match_making_version": "2.4.3",
+        "nex_messaging_version": "2.4.3",
+        "nex_utility_version": "2.4.3"
     },
     {
         "name": "MARIO KART 8",
         "access_key": "25dbf96a",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 4
-        }
+        "nex_version": "3.5.4",
+        "nex_ranking_version": "3.5.4",
+        "nex_datastore_version": "3.5.4",
+        "nex_match_making_version": "3.5.4",
+        "nex_messaging_version": "3.5.4",
+        "nex_utility_version": "3.5.4"
     },
     {
         "name": "Mario Tennis Open",
         "access_key": "0fabeff2",
-        "nex_version": {
-            "major": 2,
-            "minor": 6,
-            "patch": 1
-        }
+        "nex_version": "2.6.1",
+        "nex_ranking_version": "2.6.1",
+        "nex_datastore_version": "2.6.1",
+        "nex_match_making_version": "2.6.1",
+        "nex_messaging_version": "2.6.1",
+        "nex_utility_version": "2.6.1"
     },
     {
         "name": "Mario Tennis: Ultra Smash",
         "access_key": "c69b92a0",
-        "nex_version": {
-            "major": 3,
-            "minor": 9,
-            "patch": 1
-        }
+        "nex_version": "3.9.1",
+        "nex_ranking_version": "3.9.1",
+        "nex_datastore_version": "3.9.1",
+        "nex_match_making_version": "3.9.1",
+        "nex_messaging_version": "3.9.1",
+        "nex_utility_version": "3.9.1"
     },
     {
         "name": "Mario vs. DK: Tipping Stars",
         "access_key": "d8927c3f",
-        "nex_version": {
-            "major": 3,
-            "minor": 7,
-            "patch": 1
-        }
+        "nex_version": "3.7.1",
+        "nex_ranking_version": "3.7.1",
+        "nex_datastore_version": "3.7.1",
+        "nex_match_making_version": "3.7.1",
+        "nex_messaging_version": "3.7.1",
+        "nex_utility_version": "3.7.1"
     },
     {
         "name": "Metroid Prime: FF",
         "access_key": "f79fb3c5",
-        "nex_version": {
-            "major": 3,
-            "minor": 9,
-            "patch": 1
-        }
+        "nex_version": "3.9.1",
+        "nex_ranking_version": "3.9.1",
+        "nex_datastore_version": "3.9.1",
+        "nex_match_making_version": "3.9.1",
+        "nex_messaging_version": "3.9.1",
+        "nex_utility_version": "3.9.1"
     },
     {
         "name": "MH3G HD Ver.",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 5
-        }
+        "nex_version": "3.0.5",
+        "nex_ranking_version": "3.0.5",
+        "nex_datastore_version": "3.0.5",
+        "nex_match_making_version": "3.0.5",
+        "nex_messaging_version": "3.0.5",
+        "nex_utility_version": "3.0.5"
     },
     {
         "name": "MH3U",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 5
-        }
+        "nex_version": "3.0.5",
+        "nex_ranking_version": "3.0.5",
+        "nex_datastore_version": "3.0.5",
+        "nex_match_making_version": "3.0.5",
+        "nex_messaging_version": "3.0.5",
+        "nex_utility_version": "3.0.5"
     },
     {
         "name": "Mighty No. 9",
         "access_key": "bb980c2e",
-        "nex_version": {
-            "major": 3,
-            "minor": 9,
-            "patch": 1
-        }
+        "nex_version": "3.9.1",
+        "nex_ranking_version": "3.9.1",
+        "nex_datastore_version": "3.9.1",
+        "nex_match_making_version": "3.9.1",
+        "nex_messaging_version": "3.9.1",
+        "nex_utility_version": "3.9.1"
     },
     {
         "name": "Minecraft: Wii U Edition",
         "access_key": "f1b61c8e",
-        "nex_version": {
-            "major": 3,
-            "minor": 10,
-            "patch": 0
-        }
+        "nex_version": "3.10.0",
+        "nex_ranking_version": "3.10.0",
+        "nex_datastore_version": "3.10.0",
+        "nex_match_making_version": "3.10.0",
+        "nex_messaging_version": "3.10.0",
+        "nex_utility_version": "3.10.0"
     },
     {
         "name": "Nano Assault Neo",
         "access_key": "7e484a8e",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "NINJA GAIDEN 3: Razor's Edge",
         "access_key": "f857b4bd",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "Nova-111",
         "access_key": "bafe9856",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 3
-        }
+        "nex_version": "3.8.3",
+        "nex_ranking_version": "3.8.3",
+        "nex_datastore_version": "3.8.3",
+        "nex_match_making_version": "3.8.3",
+        "nex_messaging_version": "3.8.3",
+        "nex_utility_version": "3.8.3"
     },
     {
         "name": "OlliOlli",
         "access_key": "60e5df12",
-        "nex_version": {
-            "major": 3,
-            "minor": 6,
-            "patch": 1
-        }
+        "nex_version": "3.6.1",
+        "nex_ranking_version": "3.6.1",
+        "nex_datastore_version": "3.6.1",
+        "nex_match_making_version": "3.6.1",
+        "nex_messaging_version": "3.6.1",
+        "nex_utility_version": "3.6.1"
     },
     {
         "name": "PIKMIN 3",
         "access_key": "f6accfc1",
-        "nex_version": {
-            "major": 3,
-            "minor": 3,
-            "patch": 0
-        }
+        "nex_version": "3.3.0",
+        "nex_ranking_version": "3.3.0",
+        "nex_datastore_version": "3.3.0",
+        "nex_match_making_version": "3.3.0",
+        "nex_messaging_version": "3.3.0",
+        "nex_utility_version": "3.3.0"
     },
     {
         "name": "Pokémon Bank",
         "access_key": "9a2961d8",
-        "nex_version": {
-            "major": 3,
-            "minor": 4,
-            "patch": 12
-        }
+        "nex_version": "3.4.12",
+        "nex_ranking_version": "3.4.12",
+        "nex_datastore_version": "3.4.12",
+        "nex_match_making_version": "3.4.12",
+        "nex_messaging_version": "3.4.12",
+        "nex_utility_version": "3.4.12"
     },
     {
         "name": "Pokémon Rumble World",
         "access_key": "844f1d0c",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 2
-        }
+        "nex_version": "3.8.2",
+        "nex_ranking_version": "3.8.2",
+        "nex_datastore_version": "3.8.2",
+        "nex_match_making_version": "3.8.2",
+        "nex_messaging_version": "3.8.2",
+        "nex_utility_version": "3.8.2"
     },
     {
         "name": "POKKÉN TOURNAMENT",
         "access_key": "6ef3adf1",
-        "nex_version": {
-            "major": 3,
-            "minor": 10,
-            "patch": 0
-        }
+        "nex_version": "3.10.0",
+        "nex_ranking_version": "3.10.0",
+        "nex_datastore_version": "3.10.0",
+        "nex_match_making_version": "3.10.0",
+        "nex_messaging_version": "3.10.0",
+        "nex_utility_version": "3.10.0"
     },
     {
         "name": "Puddle",
         "access_key": "afcffb5c",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "PUYOPUYOTETRIS",
         "access_key": "4eb0ca36",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 2
-        }
+        "nex_version": "3.5.2",
+        "nex_ranking_version": "3.5.2",
+        "nex_datastore_version": "3.5.2",
+        "nex_match_making_version": "3.5.2",
+        "nex_messaging_version": "3.5.2",
+        "nex_utility_version": "3.5.2"
     },
     {
         "name": "RESIDENT EVIL REVELATIONS",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 2,
-            "patch": 1
-        }
+        "nex_version": "3.2.1",
+        "nex_ranking_version": "3.2.1",
+        "nex_datastore_version": "3.2.1",
+        "nex_match_making_version": "3.2.1",
+        "nex_messaging_version": "3.2.1",
+        "nex_utility_version": "3.2.1"
     },
     {
         "name": "RTK 12",
         "access_key": "bfede098",
-        "nex_version": {
-            "major": 3,
-            "minor": 4,
-            "patch": 0
-        }
+        "nex_version": "3.4.0",
+        "nex_ranking_version": "3.4.0",
+        "nex_datastore_version": "3.4.0",
+        "nex_match_making_version": "3.4.0",
+        "nex_messaging_version": "3.4.0",
+        "nex_utility_version": "3.4.0"
     },
     {
         "name": "Runner2",
         "access_key": "1084452a",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "SI2",
         "access_key": "44adeb87",
-        "nex_version": {
-            "major": 3,
-            "minor": 6,
-            "patch": 1
-        }
+        "nex_version": "3.6.1",
+        "nex_ranking_version": "3.6.1",
+        "nex_datastore_version": "3.6.1",
+        "nex_match_making_version": "3.6.1",
+        "nex_messaging_version": "3.6.1",
+        "nex_utility_version": "3.6.1"
     },
     {
         "name": "SONIC LOST WORLD",
         "access_key": "69a9fc95",
-        "nex_version": {
-            "major": 3,
-            "minor": 3,
-            "patch": 0
-        }
+        "nex_version": "3.3.0",
+        "nex_ranking_version": "3.3.0",
+        "nex_datastore_version": "3.3.0",
+        "nex_match_making_version": "3.3.0",
+        "nex_messaging_version": "3.3.0",
+        "nex_utility_version": "3.3.0"
     },
     {
         "name": "Sonic Transformed",
         "access_key": "b26a3421",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "Splatoon",
         "access_key": "6f599f81",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 3
-        }
+        "nex_version": "3.8.3",
+        "nex_ranking_version": "3.8.3",
+        "nex_datastore_version": "3.8.3",
+        "nex_match_making_version": "3.8.3",
+        "nex_messaging_version": "3.8.3",
+        "nex_utility_version": "3.8.3"
     },
     {
         "name": "Star Fox Guard",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 2
-        }
+        "nex_version": "3.8.2",
+        "nex_ranking_version": "3.8.2",
+        "nex_datastore_version": "3.8.2",
+        "nex_match_making_version": "3.8.2",
+        "nex_messaging_version": "3.8.2",
+        "nex_utility_version": "3.8.2"
     },
     {
         "name": "Star Fox Guard (Demo)",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 2
-        }
+        "nex_version": "3.8.2",
+        "nex_ranking_version": "3.8.2",
+        "nex_datastore_version": "3.8.2",
+        "nex_match_making_version": "3.8.2",
+        "nex_messaging_version": "3.8.2",
+        "nex_utility_version": "3.8.2"
     },
     {
         "name": "Star Wars Pinball",
         "access_key": "ecd0e530",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "Steel Diver: Sub Wars",
         "access_key": "fb9537fe",
-        "nex_version": {
-            "major": 3,
-            "minor": 7,
-            "patch": 0
-        }
+        "nex_version": "3.7.0",
+        "nex_ranking_version": "3.7.0",
+        "nex_datastore_version": "3.7.0",
+        "nex_match_making_version": "3.7.0",
+        "nex_messaging_version": "3.7.0",
+        "nex_utility_version": "3.7.0"
     },
     {
         "name": "Super Mario Maker",
         "access_key": "9f2b4678",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 12
-        }
+        "nex_version": "3.8.12",
+        "nex_ranking_version": "3.8.12",
+        "nex_datastore_version": "3.8.12",
+        "nex_match_making_version": "3.8.12",
+        "nex_messaging_version": "3.8.12",
+        "nex_utility_version": "3.8.12"
     },
     {
         "name": "Super Smash Bros.",
         "access_key": "2869ba38",
-        "nex_version": {
-            "major": 3,
-            "minor": 6,
-            "patch": 27
-        }
+        "nex_version": "3.6.27",
+        "nex_ranking_version": "3.6.27",
+        "nex_datastore_version": "3.6.27",
+        "nex_match_making_version": "3.6.27",
+        "nex_messaging_version": "3.6.27",
+        "nex_utility_version": "3.6.27"
     },
     {
         "name": "Team Kirby Clash Deluxe",
         "access_key": "e0c85605",
-        "nex_version": {
-            "major": 3,
-            "minor": 10,
-            "patch": 1
-        }
+        "nex_version": "3.10.1",
+        "nex_ranking_version": "3.10.1",
+        "nex_datastore_version": "3.10.1",
+        "nex_match_making_version": "3.10.1",
+        "nex_messaging_version": "3.10.1",
+        "nex_utility_version": "3.10.1"
     },
     {
         "name": "TEKKEN TAG 2 Wii U EDITION",
         "access_key": "0f037f64",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "Terraria",
         "access_key": "3d37fbdb",
-        "nex_version": {
-            "major": 3,
-            "minor": 8,
-            "patch": 3
-        }
+        "nex_version": "3.8.3",
+        "nex_ranking_version": "3.8.3",
+        "nex_datastore_version": "3.8.3",
+        "nex_match_making_version": "3.8.3",
+        "nex_messaging_version": "3.8.3",
+        "nex_utility_version": "3.8.3"
     },
     {
         "name": "Trine 2",
         "access_key": "f9c35adc",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "WARRIORS OROCHI 3 Hyper",
         "access_key": "d74bb27d",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "Wii Karaoke U",
         "access_key": "dfc5a4ac",
-        "nex_version": {
-            "major": 3,
-            "minor": 4,
-            "patch": 0
-        }
+        "nex_version": "3.4.0",
+        "nex_ranking_version": "3.4.0",
+        "nex_datastore_version": "3.4.0",
+        "nex_match_making_version": "3.4.0",
+        "nex_messaging_version": "3.4.0",
+        "nex_utility_version": "3.4.0"
     },
     {
         "name": "Wii Party U",
         "access_key": "a5b77314",
-        "nex_version": {
-            "major": 3,
-            "minor": 3,
-            "patch": 0
-        }
+        "nex_version": "3.3.0",
+        "nex_ranking_version": "3.3.0",
+        "nex_datastore_version": "3.3.0",
+        "nex_match_making_version": "3.3.0",
+        "nex_messaging_version": "3.3.0",
+        "nex_utility_version": "3.3.0"
     },
     {
         "name": "Wii Sports Club",
         "access_key": "4d324052",
-        "nex_version": {
-            "major": 3,
-            "minor": 4,
-            "patch": 7
-        }
+        "nex_version": "3.4.7",
+        "nex_ranking_version": "3.4.7",
+        "nex_datastore_version": "3.4.7",
+        "nex_match_making_version": "3.4.7",
+        "nex_messaging_version": "3.4.7",
+        "nex_utility_version": "3.4.7"
     },
     {
         "name": "Xenoblade Chronicles X",
         "access_key": "",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 5
-        }
+        "nex_version": "3.5.5",
+        "nex_ranking_version": "3.5.5",
+        "nex_datastore_version": "3.5.5",
+        "nex_match_making_version": "3.5.5",
+        "nex_messaging_version": "3.5.5",
+        "nex_utility_version": "3.5.5"
     },
     {
         "name": "XenobladeX",
         "access_key": "59d7be84",
-        "nex_version": {
-            "major": 3,
-            "minor": 5,
-            "patch": 5
-        }
+        "nex_version": "3.5.5",
+        "nex_ranking_version": "3.5.5",
+        "nex_datastore_version": "3.5.5",
+        "nex_match_making_version": "3.5.5",
+        "nex_messaging_version": "3.5.5",
+        "nex_utility_version": "3.5.5"
     },
     {
         "name": "Yo-kai Watch 2",
         "access_key": "7ab183bb",
-        "nex_version": {
-            "major": 3,
-            "minor": 6,
-            "patch": 1
-        }
+        "nex_version": "3.6.1",
+        "nex_ranking_version": "3.6.1",
+        "nex_datastore_version": "3.6.1",
+        "nex_match_making_version": "3.6.1",
+        "nex_messaging_version": "3.6.1",
+        "nex_utility_version": "3.6.1"
     },
     {
         "name": "Zen Pinball 2",
         "access_key": "2ff15f7e",
-        "nex_version": {
-            "major": 3,
-            "minor": 0,
-            "patch": 1
-        }
+        "nex_version": "3.0.1",
+        "nex_ranking_version": "3.0.1",
+        "nex_datastore_version": "3.0.1",
+        "nex_match_making_version": "3.0.1",
+        "nex_messaging_version": "3.0.1",
+        "nex_utility_version": "3.0.1"
     },
     {
         "name": "役満 鳳凰",
         "access_key": "23aab2d3",
-        "nex_version": {
-            "major": 3,
-            "minor": 6,
-            "patch": 14
-        }
+        "nex_version": "3.6.14",
+        "nex_ranking_version": "3.6.14",
+        "nex_datastore_version": "3.6.14",
+        "nex_match_making_version": "3.6.14",
+        "nex_messaging_version": "3.6.14",
+        "nex_utility_version": "3.6.14"
     },
     {
         "name": "Kid Icarus Uprising",
         "access_key": "58a7e494",
-        "nex_version": {
-            "major": 0,
-            "minor": 0,
-            "patch": 0
-        }
+        "nex_version": "0.0.0"
     },
     {
         "name": "Luigi's Mansion 2",
         "access_key": "3861a9f8",
-        "nex_version": {
-            "major": 0,
-            "minor": 0,
-            "patch": 0
-        }
+        "nex_version": "0.0.0"
     },
     {
         "name": "Pokémon X/Y",
         "access_key": "876138df",
-        "nex_version": {
-            "major": 0,
-            "minor": 0,
-            "patch": 0
-        }
+        "nex_version": "0.0.0"
     },
     {
         "name": "TLoZ: Tri Force Heroes",
         "access_key": "c1621b84",
-        "nex_version": {
-            "major": 0,
-            "minor": 0,
-            "patch": 0
-        }
+        "nex_version": "0.0.0"
     }
 ]

--- a/src/types.js
+++ b/src/types.js
@@ -1,3 +1,4 @@
+const semver = require('semver');
 const Stream = require('./stream'); // eslint-disable-line no-unused-vars
 
 class Structure {
@@ -36,7 +37,7 @@ class Structure {
 			this._parentTypes.push(stream.readNEXStructure(parentTypeClass));
 		}
 
-		if (stream.connection.title.nex_version.major >= 3 && stream.connection.title.nex_version.minor >= 5) {
+		if (semver.gte(stream.connection.title.nex_version.major, '3.5.0')) {
 			this._structureHeader = {
 				version: stream.readUInt8(),
 				contentLength: stream.readUInt32LE()

--- a/src/types.js
+++ b/src/types.js
@@ -37,7 +37,7 @@ class Structure {
 			this._parentTypes.push(stream.readNEXStructure(parentTypeClass));
 		}
 
-		if (semver.gte(stream.connection.title.nex_version.major, '3.5.0')) {
+		if (semver.gte(stream.connection.title.nex_version, '3.5.0')) {
 			this._structureHeader = {
 				version: stream.readUInt8(),
 				contentLength: stream.readUInt32LE()


### PR DESCRIPTION
NEX versions are just semver, which are non-trivial to accurately compare against

For instance, in some cases we had checks such as `major >= 3 && minor >= 5` for validating if something is above NEX `3.5.0`. However this breaks down when we have instances where the NEX version is something like `4.0.0`. Now suddenly this check fails, because even though `4` is greater than `3`, the minor version is smaller

This PR does 3 things

- Convert our `nex_version` objects into semver strings
- Use the [semver](https://www.npmjs.com/package/semver) module to compare versions
- updates the `nex/` version lists to all be the same. We track them separately because there are rare cases where certain protocols have different versions, however the vast majority of the time each has the same version. Any differences can just be patched in later