### PR TITLE
Search bar

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -20,6 +20,17 @@ body {
 	color: white;
 	padding: 5px;
 	font-family: system-ui;
+	display: flex;
+	align-items: flex-start;
+	gap: 20px;
+}
+
+#header-search {
+	flex: 1;
+}
+
+.search-hidden {
+	display: none;
 }
 
 main {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -21,7 +21,7 @@ body {
 	padding: 5px;
 	font-family: system-ui;
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	gap: 20px;
 }
 

--- a/app/assets/js/renderer.js
+++ b/app/assets/js/renderer.js
@@ -12,10 +12,31 @@ const packetsSection = document.getElementById('packets');
 export const packetDetailsSection = document.getElementById('packet-details');
 export const connectionsListSection = document.getElementById('connections-list');
 export const packetsTableBodySection = packetsSection.querySelector('tbody');
+let selectedPacket;
 let displayPingPackets = false;
 
 const LIST_TYPE_REGEX = /List<(.*)>/;
 const MAP_TYPE_REGEX = /Map<(.*)>/;
+
+document.querySelector('#header-search').addEventListener('keyup', event => {
+	const filter = event.target.value;
+
+	const packets = packetsTableBodySection.querySelectorAll('tr[data-serialized]');
+
+	for (const packet of packets) {
+		if (packet.outerHTML.toLowerCase().includes(filter.toLowerCase())) {
+			packet.classList.remove('search-hidden');
+		} else {
+			packet.classList.add('search-hidden');
+		}
+	}
+
+	if (filter.trim() === '') {
+		if (selectedPacket) {
+			selectedPacket.scrollIntoView({block: 'nearest', inline: 'nearest'});
+		}
+	}
+});
 
 /**
  * @returns {void}
@@ -230,6 +251,8 @@ export function addPacketToList(packet) {
 function setSelectedPacketRow(tr) {
 	document.querySelector('tr.selected')?.classList.toggle('selected');
 	tr.classList.toggle('selected');
+
+	selectedPacket = tr;
 
 	updatePacketDetails(JSON.parse(tr.dataset.serialized));
 }

--- a/app/index.html
+++ b/app/index.html
@@ -13,7 +13,8 @@
 	</head>
 	<body>
 		<section id="header">
-			NEX Viewer
+			<span id="header-title">NEX Viewer</span>
+			<input id="header-search" type="text" placeholder="Search...">
 		</section>
 
 		<main>


### PR DESCRIPTION
Adds in a really basic search bar. The filtering is not as robust as what's found in tools like WireShark, but I think it's good enough for us. It just does a basic "does the text include the searched phrase" for all packets and their serialized bodies. If the search filter is deleted, it also scrolls back to the currently selected packet, if there is one, so that way you can select a packet while searching and then jump to where it's at