### PR TITLE
Make non-raw pcaps work

### DIFF
--- a/src/pcap-parser.js
+++ b/src/pcap-parser.js
@@ -2,6 +2,7 @@ const Stream = require('./stream');
 
 const LINKTYPE_ETHERNET = 0x0001;
 const LINKTYPE_RAW = 0x0065;
+
 class PCAPParser {
 	#buffer;
 	#stream;

--- a/src/pcapng-parser.js
+++ b/src/pcapng-parser.js
@@ -89,8 +89,6 @@ class PCAPNGParser {
 
 		section.options = this.#parseOptionalData(optionsLength);
 
-		this.#stream.seek((blockStart + blockLength) - 4); // * Skip optional data
-
 		const blockLength2 = this.#readUInt32();
 
 		if (blockLength !== blockLength2) {


### PR DESCRIPTION
Reads the `network` (link layer) field from the pcap global header and uses that to determine the size of the link layer header. This makes pcaps which don't use `LINKTYPE_RAW` work