### PR TITLE
Support Switch/PRUDPLite

### DIFF
--- a/app/assets/js/renderer.js
+++ b/app/assets/js/renderer.js
@@ -70,8 +70,10 @@ export function populateConnectionsList(connections) {
 
 		let title;
 
-		// * Hack to detect raw RMC connections
-		if (connection.discriminator !== 'authentication' && connection.discriminator !== 'secure') {
+		// * Hack to detect raw RMC and WSS connections
+		if (connection.type === 'wss') {
+			title = `${connection.discriminator} ${connection.title.name || 'Unknown'}`;
+		} else if (connection.discriminator !== 'authentication' && connection.discriminator !== 'secure') {
 			title = `${connection.discriminator} ${connection.title.name || 'Unknown'} (${connection.secure ? 'Secure' : 'Authentication'})`;
 		} else {
 			title = `${connection.title.name || 'Unknown'} (${connection.secure ? 'Secure' : 'Authentication'})`;
@@ -218,9 +220,36 @@ export function addPacketToList(packet) {
 	}
 
 	const timeString = packet.rawRMC ? '' : packet.date;
-	const sourceString = packet.rawRMC ? '' : packet.sourceAddress;
-	const destinationString = packet.rawRMC ? '' : packet.destinationAddress;
-	const versionString = packet.rawRMC ? 'Raw RMC' : `v${packet.version}`;
+	let sourceString = '';
+
+	if (packet.rawRMC) {
+		sourceString = '';
+	} else if (packet.version === 'lite') {
+		sourceString = packet.source;
+	} else {
+		sourceString = packet.sourceAddress;
+	}
+
+	let destinationString = '';
+
+	if (packet.rawRMC) {
+		destinationString = '';
+	} else if (packet.version === 'lite') {
+		destinationString = packet.destination;
+	} else {
+		destinationString = packet.destinationAddress;
+	}
+
+	let versionString = '';
+
+	if (packet.rawRMC) {
+		versionString = 'Raw RMC';
+	} else if (packet.version === 'lite') {
+		versionString = 'Lite';
+	} else {
+		versionString = `v${packet.version}`;
+	}
+
 	const infoString = infoData.join(', ');
 
 	time.appendChild(document.createTextNode(timeString));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "fs-extra": "^11.1.1",
         "private-ip": "^2.3.4",
         "semver": "^7.5.4"
       },
@@ -74,6 +75,29 @@
         "global-agent": "^3.0.0"
       }
     },
+    "node_modules/@electron/get/node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@electron/get/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/@electron/get/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -81,6 +105,15 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@electron/get/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/@electron/notarize": {
@@ -110,27 +143,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@electron/notarize/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/notarize/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron/osx-sign": {
@@ -180,27 +192,6 @@
         "url": "https://github.com/sponsors/gjtorikian/"
       }
     },
-    "node_modules/@electron/osx-sign/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/osx-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron/universal": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.4.1.tgz",
@@ -232,27 +223,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -385,27 +355,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -738,18 +687,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/app-builder-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/app-builder-lib/node_modules/minimatch": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -760,15 +697,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/argparse": {
@@ -1007,27 +935,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/builder-util/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/builder-util/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -1420,27 +1327,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/dmg-builder/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/dmg-license": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
@@ -1567,27 +1453,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/electron-builder/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-builder/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/electron-publish": {
       "version": "24.5.0",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.5.0.tgz",
@@ -1615,27 +1480,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/electron-publish/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-publish/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -2079,17 +1923,16 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
+        "node": ">=14.14"
       }
     },
     "node_modules/fs-minipass": {
@@ -2314,8 +2157,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -2721,10 +2563,12 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3674,27 +3518,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/temp-file/node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/temp-file/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3787,12 +3610,11 @@
       "dev": true
     },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/uri-js": {
@@ -3983,10 +3805,36 @@
         "sumchecker": "^3.0.1"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
         "semver": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
         }
       }
@@ -4013,22 +3861,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
         }
       }
     },
@@ -4062,22 +3894,6 @@
           "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
           "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
           "dev": true
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
         }
       }
     },
@@ -4107,22 +3923,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
         }
       }
     },
@@ -4215,22 +4015,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
         }
       }
     },
@@ -4508,16 +4292,6 @@
             "universalify": "^2.0.0"
           }
         },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
         "minimatch": {
           "version": "5.1.6",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
@@ -4526,12 +4300,6 @@
           "requires": {
             "brace-expansion": "^2.0.1"
           }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
         }
       }
     },
@@ -4701,22 +4469,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
         }
       }
     },
@@ -5021,22 +4773,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
         }
       }
     },
@@ -5127,22 +4863,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
         }
       }
     },
@@ -5171,22 +4891,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
         }
       }
     },
@@ -5536,14 +5240,13 @@
       }
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
       "requires": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       }
     },
     "fs-minipass": {
@@ -5710,8 +5413,7 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -6001,12 +5703,12 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
       }
     },
     "keyv": {
@@ -6696,22 +6398,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
           }
-        },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
-          }
-        },
-        "universalify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-          "dev": true
         }
       }
     },
@@ -6785,10 +6471,9 @@
       "dev": true
     },
     "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "license": "ISC",
   "dependencies": {
+    "fs-extra": "^11.1.1",
     "private-ip": "^2.3.4",
     "semver": "^7.5.4"
   },

--- a/src/connection.js
+++ b/src/connection.js
@@ -459,5 +459,4 @@ class Connection {
 	}
 }
 
-
 module.exports = Connection;

--- a/src/packet-lite.js
+++ b/src/packet-lite.js
@@ -1,0 +1,113 @@
+/**
+ * @typedef {import('./connection')} Connection
+ */
+
+const Packet = require('./packet');
+const Stream = require('./stream');
+
+const OPTION_SUPPORTED_FUNCTIONS = 0;
+const OPTION_CONNECTION_SIGNATURE = 1;
+const OPTION_FRAGMENT_ID = 2;
+const OPTION_INITIAL_SEQUENCE_ID = 3;
+const OPTION_MAX_SUBSTREAM_ID = 4;
+const OPTION_LITE_SIGNATURE = 0x80;
+
+class PacketLite extends Packet {
+	/**
+	 *
+	 * @param {Connection} connection NEX connection
+	 * @param {Stream} stream Packet data stream
+	 */
+	constructor(connection, stream) {
+		super(connection, stream);
+
+		this.version = 'lite';
+		this.source = '';
+		this.destination = '';
+		this.sourceStreamType;
+		this.destinationStreamType;
+		this.sourcePort;
+		this.destinationPort;
+		this.fragmentId;
+		this.flags;
+		this.type;
+		this.sequenceId;
+		this.packetSpecificData;
+		this.payload;
+
+		this.prudpProtocolMinorVersion;
+		this.supportedFunctions;
+		this.initialSequenceId;
+		this.maximumSubstreamId;
+		this.liteSignature;
+	}
+
+	decode() {
+		const magic = this.stream.readUInt8();
+
+		if (magic !== 0x80) {
+			throw new Error(`Invalid PRUDPLite magic ${magic.toString('16')}`);
+		}
+
+		const packetSpecificDataLength = this.stream.readUInt8();
+		const payloadSize = this.stream.readUInt16LE();
+		const streamTypes = this.stream.readUInt8();
+		this.sourceStreamType = (streamTypes & 0xF0) >> 4;
+		this.destinationStreamType = streamTypes & 0x0F;
+		this.sourcePort = this.stream.readUInt8();
+		this.destinationPort = this.stream.readUInt8();
+		this.fragmentId = this.stream.readUInt8();
+		const typeAndFlags = this.stream.readUInt16LE();
+		this.flags = typeAndFlags >> 4;
+		this.type = typeAndFlags & 0xF;
+		this.sequenceId = this.stream.readUInt16LE();
+		this.packetSpecificData = this.stream.readBytes(packetSpecificDataLength);
+
+		this.parsePacketSpecificData();
+
+		this.payload = this.stream.readBytes(payloadSize);
+	}
+
+	parsePacketSpecificData() {
+		const packetSpecificDataStream = new Stream(this.packetSpecificData);
+
+		while (packetSpecificDataStream.hasDataLeft()) {
+			const optionId = packetSpecificDataStream.readUInt8();
+			const optionSize = packetSpecificDataStream.readUInt8();
+
+			switch (optionId) {
+			case OPTION_SUPPORTED_FUNCTIONS: {
+				const optionData = packetSpecificDataStream.readUInt32LE();
+				this.prudpProtocolMinorVersion = optionData & 0xFF;
+				this.supportedFunctions = optionData >> 8;
+				break;
+			}
+			case OPTION_CONNECTION_SIGNATURE:
+				this.connectionSignature = packetSpecificDataStream.readBytes(optionSize);
+				break;
+			case OPTION_FRAGMENT_ID:
+				this.fragmentId = packetSpecificDataStream.readUInt8();
+				break;
+			case OPTION_INITIAL_SEQUENCE_ID:
+				this.initialSequenceId = packetSpecificDataStream.readUInt16LE();
+				break;
+			case OPTION_MAX_SUBSTREAM_ID:
+				this.maximumSubstreamId = packetSpecificDataStream.readUInt8();
+				break;
+			case OPTION_LITE_SIGNATURE:
+				this.liteSignature = packetSpecificDataStream.readBytes(optionSize);
+				break;
+			}
+		}
+	}
+
+	isToClient() {
+		return this.source === 'server';
+	}
+
+	isToServer() {
+		return this.source === 'client';
+	}
+}
+
+module.exports = PacketLite;

--- a/src/packet.js
+++ b/src/packet.js
@@ -94,7 +94,7 @@ class Packet {
 			serialized.source = this.source;
 			serialized.destination = this.destination;
 			serialized.sessionId = this.sessionId;
-			serialized.signature = this.signature.toString('hex');
+			serialized.signature = this.signature?.toString('hex') || '';
 			serialized.sequenceId = this.sequenceId;
 			serialized.fragmentId = this.fragmentId;
 			serialized.checksum = this.checksum;

--- a/src/titles.json
+++ b/src/titles.json
@@ -1121,5 +1121,33 @@
             "0004000000182200",
             "0004000000182300"
         ]
+    },
+    {
+        "name": "Mario Kart 8 Deluxe",
+        "game_server_id": "2b309e01",
+        "access_key": "09c1c475",
+        "nex_version": "4.3.2",
+        "nex_ranking_version": "4.3.2",
+        "nex_datastore_version": "4.3.2",
+        "nex_match_making_version": "4.3.2",
+        "nex_messaging_version": "4.3.2",
+        "nex_utility_version": "4.3.2",
+        "title_ids": [
+            "0100152000022000"
+        ]
+    },
+    {
+        "name": "Super Mario Maker 2",
+        "game_server_id": "22306d00",
+        "access_key": "fdf6617f",
+        "nex_version": "4.6.25",
+        "nex_ranking_version": "4.6.25",
+        "nex_datastore_version": "4.6.25",
+        "nex_match_making_version": "4.6.25",
+        "nex_messaging_version": "4.6.25",
+        "nex_utility_version": "4.6.25",
+        "title_ids": [
+            "01009B90006DC000"
+        ]
     }
 ]

--- a/src/websocket-connection.js
+++ b/src/websocket-connection.js
@@ -1,0 +1,145 @@
+/**
+ * @typedef {import('./packet-lite')} PacketLite
+ */
+
+const FragmentationManager = require('./fragmentation_manager');
+const RMCMessage = require('./rmc');
+const Protocols = require('./protocols');
+const titles = require('./titles.json');
+
+class WebSocketConnection {
+	constructor(discriminator) {
+		this.discriminator = discriminator;
+		this.packets = [];
+		this.title = {
+			name: '',
+			title_ids: [],
+			access_key: '',
+			nex_version: '0.0.0',
+			nex_ranking_version: '0.0.0',
+			nex_datastore_version: '0.0.0',
+			nex_match_making_version: '0.0.0',
+			nex_messaging_version: '0.0.0',
+			nex_utility_version: '0.0.0'
+		};
+
+		this.clientFragmentationManager = new FragmentationManager();
+		this.serverFragmentationManager = new FragmentationManager();
+	}
+
+	toJSON() {
+		return {
+			discriminator: this.discriminator,
+			title: this.title,
+			type: 'wss'
+		};
+	}
+
+	configure(gameServerID) {
+		for (const title of titles) {
+			if (title.game_server_id === gameServerID) {
+				this.title = title;
+				break;
+			}
+		}
+
+		if (this.title.name === '') {
+			throw new Error(`Unsupported game server ID ${gameServerID}`);
+		}
+	}
+
+	/**
+	 *
+	 * @param {(PacketLite)} packet PRUDPLite packet
+	 */
+	handlePacket(packet) {
+		if (packet.isData() && !packet.hasFlagReliable()) {
+			this.packets.push(packet);
+			return;
+		}
+
+		if (packet.hasFlagAck() || packet.hasFlagMultiAck()) {
+			// TODO - Parse these for their sequence IDs
+			this.packets.push(packet);
+			return;
+		}
+
+		if (packet.isPing()) {
+			// * Ping packets contain no useful information
+			this.packets.push(packet);
+			return;
+		}
+
+		if (packet.isData()) {
+			let fragments;
+
+			if (packet.isToServer()) {
+				fragments = this.clientFragmentationManager.update(packet);
+			} else {
+				fragments = this.serverFragmentationManager.update(packet);
+			}
+
+			if (packet.fragmentId === 0) {
+				const payloads = [];
+
+				for (const fragment of fragments) {
+					payloads.push(fragment.payload);
+				}
+
+				const defragmentedPayload = Buffer.concat(payloads);
+
+				packet.rmcMessage = new RMCMessage(defragmentedPayload);
+
+				// * If the packet has a custom ID, check the protocol list with it
+				let protocolId;
+				if (packet.rmcMessage.protocolId === 0x7F) {
+					protocolId = packet.rmcMessage.customId;
+				} else {
+					protocolId = packet.rmcMessage.protocolId;
+				}
+
+				const protocol = Protocols[protocolId];
+
+				if (!protocol) {
+					console.log(`Unknown protocol ID ${protocolId} (0x${protocolId.toString(16)})`);
+					this.packets.push(packet);
+					return;
+				}
+
+				if (!packet.rmcMessage.isRequest() && !packet.rmcMessage.isSuccess()) {
+					const requestPacket = this.packets.find(p => {
+						if (
+							p.rmcMessage.isRequest() &&
+							p.rmcMessage.protocolId === packet.rmcMessage.protocolId &&
+							p.rmcMessage.callId === packet.rmcMessage.callId
+						) {
+							return true;
+						}
+					});
+
+					if (requestPacket) {
+						packet.rmcMessage.methodId = requestPacket.rmcMessage.methodId;
+					}
+				} else {
+					try {
+						protocol.handlePacket(packet);
+					} catch (error) {
+						packet.stackTrace = error.stack;
+					}
+				}
+
+				if (!packet.rmcData.protocolName) {
+					packet.rmcData.protocolName = protocol.ProtocolName;
+				}
+
+				if (!packet.rmcData.methodName) {
+					packet.rmcData.methodName = protocol.MethodNames[packet.rmcMessage.methodId];
+				}
+			}
+		}
+
+		this.packets.push(packet);
+	}
+}
+
+module.exports = WebSocketConnection;


### PR DESCRIPTION
PR adds in support for PRUDPLite, which is used by Switch servers. It's implemented using a different connection class as the handling is pretty different, due to the lack of crypto. Currently the only format accepted is the BIN format that Charles produces, as it's the easiest way to get Switch traffic. PR does not aim to implement Switch/NEX 4.0+ support in the protocols, only the ability to read the connections. Protocol support should come gradually, just like with the older protocols

With the impending death of Nintendo Network, viewing early Switch game traffic will be our only way to still see how a NEX server operates. This will only be the later versions, but it's better than nothing