### PR TITLE
Various fixes

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -425,7 +425,7 @@ class Connection {
 			return;
 		}
 
-		if (isResponseRMCMessage && !packet.rmcMessage.isSuccess()) {
+		if (packet.rmcMessage.isResponse() && !packet.rmcMessage.isSuccess()) {
 			const requestPacket = this.packets.find(p => {
 				if (
 					p.rmcMessage.isRequest() &&

--- a/src/packet.js
+++ b/src/packet.js
@@ -274,7 +274,7 @@ class Packet {
 	 * @returns {boolean} True if has flag
 	 */
 	isToClient() {
-		return this.source === 0xA1;
+		return (this.source & 0xF) === 0x1;
 	}
 
 	/**
@@ -282,7 +282,7 @@ class Packet {
 	 * @returns {boolean} True if has flag
 	 */
 	isToServer() {
-		return this.source === 0xAF;
+		return (this.source & 0xF) === 0xF;
 	}
 
 	/**

--- a/src/protocols/requests/match_making.js
+++ b/src/protocols/requests/match_making.js
@@ -739,7 +739,7 @@ class MigrateGatheringOwnershipV1Request {
 	 */
 	constructor(stream) {
 		this.gid = stream.readUInt32LE();
-		this.lstPotentialNewOwnersID = stream.readNEXStructure(stream.readPID);
+		this.lstPotentialNewOwnersID = stream.readNEXList(stream.readPID);
 	}
 
 	toJSON() {

--- a/src/protocols/requests/matchmake_extension.js
+++ b/src/protocols/requests/matchmake_extension.js
@@ -121,7 +121,7 @@ class CreateMatchmakeSessionRequest {
 		this.anyGathering = stream.readNEXAnyDataHolder();
 		this.strMessage = stream.readNEXString();
 
-		if (semver.gte(nexVersion, '3.5.0')) {
+		if (semver.gte(nexVersion, '3.4.0')) {
 			this.participationCount = stream.readUInt16LE();
 		}
 	}
@@ -627,14 +627,19 @@ class JoinMatchmakeSessionExRequest {
 	 * @param {Stream} stream NEX data stream
 	 */
 	constructor(stream) {
+		const nexVersion = stream.connection.title.nex_match_making_version || stream.connection.title.nex_version;
+
 		this.gid = stream.readUInt32LE();
 		this.strMessage = stream.readNEXString();
 		this.dontCareMyBlockList = stream.readBoolean();
-		this.participationCount = stream.readUInt16LE();
+
+		if (semver.gte(nexVersion, '3.4.0')) {
+			this.participationCount = stream.readUInt16LE();
+		}
 	}
 
 	toJSON() {
-		return {
+		const data =  {
 			gid: {
 				__typeName: 'uint32',
 				__typeValue: this.gid
@@ -646,12 +651,17 @@ class JoinMatchmakeSessionExRequest {
 			dontCareMyBlockList: {
 				__typeName: 'boolean',
 				__typeValue: this.dontCareMyBlockList
-			},
-			participationCount: {
-				__typeName: 'uint16',
-				__typeValue: this.participationCount
 			}
 		};
+
+		if (this.participationCount !== undefined) {
+			data.participationCount = {
+				__typeName: 'uint16',
+				__typeValue: this.participationCount
+			};
+		}
+
+		return data;
 	}
 }
 
@@ -767,7 +777,7 @@ class DebugNotifyEventRequest {
 				__typeValue: this.pid
 			},
 			mainType: {
-				__typeName: 'uui9nt32int8',
+				__typeName: 'uint32',
 				__typeValue: this.mainType
 			},
 			subType: {

--- a/src/protocols/types/message_delivery.js
+++ b/src/protocols/types/message_delivery.js
@@ -45,7 +45,11 @@ class UserMessage extends NEXTypes.Structure {
 	 * @param {Stream} stream NEX data stream
 	 */
 	parse(stream) {
+		// TODO - Support NEX 4.0+ messages
+
 		this.m_uiID = stream.readUInt32LE();
+		this.m_idRecipient = stream.readUInt32LE();
+		this.m_uiRecipientType = stream.readUInt32LE();
 		this.m_uiParentID = stream.readUInt32LE();
 		this.m_pidSender = stream.readPID();
 		this.m_receptiontime = stream.readNEXDateTime();
@@ -53,7 +57,6 @@ class UserMessage extends NEXTypes.Structure {
 		this.m_uiFlags = stream.readUInt32LE();
 		this.m_strSubject = stream.readNEXString();
 		this.m_strSender = stream.readNEXString();
-		this.m_messageRecipient = stream.readNEXStructure(MessageRecipient);
 	}
 
 	toJSON() {
@@ -66,6 +69,14 @@ class UserMessage extends NEXTypes.Structure {
 			m_uiID: {
 				__typeName: 'uint32',
 				__typeValue: this.m_uiID
+			},
+			m_idRecipient: {
+				__typeName: 'uint32',
+				__typeValue: this.m_idRecipient
+			},
+			m_uiRecipientType: {
+				__typeName: 'uint32',
+				__typeValue: this.m_uiRecipientType
 			},
 			m_uiParentID: {
 				__typeName: 'uint32',
@@ -94,10 +105,6 @@ class UserMessage extends NEXTypes.Structure {
 			m_strSender: {
 				__typeName: 'String',
 				__typeValue: this.m_strSender
-			},
-			m_messageRecipient: {
-				__typeName: 'MessageRecipient',
-				__typeValue: this.m_messageRecipient
 			}
 		};
 	}


### PR DESCRIPTION
- Fix Raw RMC mode assuming RMC requests or responses based on whether the server or the client sent the packet
- Check for stream ID on `isToClient` and `isToServer` and not the whole virtual port
- Improvements on matchmaking version checks and typos
- Use original `UserMessage` structure and not the NEX 4 version