### PR TITLE
Add HTTP viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ### Dump Formats
 - [x] [PCAP (`.pacp`)](https://www.ietf.org/archive/id/draft-gharris-opsawg-pcap-01.html)
 - [x] [PCAPNG (`.pacpng`)](https://www.ietf.org/archive/id/draft-tuexen-opsawg-pcapng-03.html)
-- [ ] [HAR (`.har`)](https://en.wikipedia.org/wiki/HAR_(file_format))
+- [x] [HAR (`.har`)](https://en.wikipedia.org/wiki/HAR_(file_format))
 - [x] [Charles (`.chls`, `.chlz`)](https://www.charlesproxy.com)
 - [x] [Mitmproxy Flows (`.flow`, `.flows`)](https://mitmproxy.org)
 - [ ] [Fiddler (`.saz`)](https://docs.telerik.com/fiddler-everywhere/knowledge-base/fiddler-archives)

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -37,6 +37,9 @@ export default defineConfig({
 	},
 	renderer: {
 		root: resolve(__dirname, 'src/electron/renderer'),
+		optimizeDeps: {
+			exclude: ['monaco-editor']
+		},
 		build: {
 			rollupOptions: {
 				input: resolve(__dirname, 'src/electron/renderer/index.html')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nex-viewer",
+  "name": "pretendo-network-viewer",
   "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nex-viewer",
+      "name": "pretendo-network-viewer",
       "version": "2.0.0",
       "hasInstallScript": true,
       "dependencies": {
@@ -24,6 +24,7 @@
         "glob": "^13.0.6",
         "lucide-vue-next": "^0.575.0",
         "mockttp": "^4.2.1",
+        "monaco-editor": "^0.56.0",
         "protobufjs": "^8.0.0",
         "reka-ui": "^2.8.2",
         "source-map-support": "^0.5.21",
@@ -4803,6 +4804,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/verror": {
       "version": "1.10.11",
       "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
@@ -8160,6 +8168,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -13204,6 +13221,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -13637,6 +13666,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
+      "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.4.8",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "glob": "^13.0.6",
     "lucide-vue-next": "^0.575.0",
     "mockttp": "^4.2.1",
+    "monaco-editor": "^0.56.0",
     "protobufjs": "^8.0.0",
     "reka-ui": "^2.8.2",
     "source-map-support": "^0.5.21",

--- a/src/charles-parser.ts
+++ b/src/charles-parser.ts
@@ -164,11 +164,16 @@ export class CharlesWebSocketMessage {
 }
 
 export class CharlesHTTPRequest {
+	private _startLine!: string;
 	private _method!: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE';
 	private _headers: { key: string; value: string }[] = [];
 	private _body?: Buffer;
 
 	// * Public getters
+	public get startLine(): string {
+		return this._startLine;
+	}
+
 	public get method(): 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' {
 		return this._method;
 	}
@@ -186,6 +191,7 @@ export class CharlesHTTPRequest {
 			return; // * This will never happen in this case.
 		}
 
+		this._startLine = transactionJSON.description.classData.values.requestHeader.description.classData.annotation[1].value;
 		this._method = transactionJSON.description.classData.values.scheme.value;
 
 		for (let i = 1; i < transactionJSON.description.classData.values.requestHeader.description.classData.values.firstLine.description.classData.annotation.length; i++) {
@@ -202,11 +208,16 @@ export class CharlesHTTPRequest {
 }
 
 export class CharlesHTTPResponse {
+	private _startLine!: string;
 	private _status!: number;
 	private _headers: { key: string; value: string }[] = [];
 	private _body?: Buffer;
 
 	// * Public getters
+	public get startLine(): string {
+		return this._startLine;
+	}
+
 	public get status(): number {
 		return this._status;
 	}
@@ -224,7 +235,8 @@ export class CharlesHTTPResponse {
 			return; // * This will never happen in this case.
 		}
 
-		this._status = Number(transactionJSON.description.classData.values.responseHeader.description.classData.annotation[1].value.split(' ')[1]);
+		this._startLine = transactionJSON.description.classData.values.responseHeader.description.classData.annotation[1].value;
+		this._status = Number(this._startLine.split(' ')[1]);
 
 		for (let i = 1; i < transactionJSON.description.classData.values.responseHeader.description.classData.values.firstLine.description.classData.annotation.length; i++) {
 			const key = transactionJSON.description.classData.values.responseHeader.description.classData.values.firstLine.description.classData.annotation[i].value;

--- a/src/charles-parser.ts
+++ b/src/charles-parser.ts
@@ -6,6 +6,11 @@ import type {
 	JavaClassDesc
 } from '@pretendonetwork/java.io';
 
+// TODO - This is duplicated from `@/session`. Move it somewhere shared?
+function int2ip(int: number): string {
+	return `${int >>> 24}.${int >> 16 & 255}.${int >> 8 & 255}.${int & 255}`;
+}
+
 export default class CharlesParser {
 	private buffer: Buffer;
 	private stream: ByteStream;
@@ -254,6 +259,7 @@ export class CharlesHTTPResponse {
 export class CharlesHTTPTransaction {
 	private _url!: URL;
 	private _protocolVersion = 'HTTP/1.1';
+	private _clientAddress = 'unknown';
 	private _clientLocalPort!: number;
 	private _clientProxyPort!: number;
 	private _serverLocalPort!: number;
@@ -269,6 +275,10 @@ export class CharlesHTTPTransaction {
 
 	public get protocolVersion(): string {
 		return this._protocolVersion;
+	}
+
+	public get clientAddress(): string {
+		return this._clientAddress;
 	}
 
 	public get clientLocalPort(): number {
@@ -317,6 +327,11 @@ export class CharlesHTTPTransaction {
 
 		if (transactionJSON.description.classData.values.protocolVersion) {
 			this._protocolVersion = transactionJSON.description.classData.values.protocolVersion.value;
+		}
+
+		// TODO - Probably breaks on IPv6 but I can't be arsed
+		if (transactionJSON.description.classData.values.clientAddress) {
+			this._clientAddress = int2ip(transactionJSON.description.classData.values.clientAddress.description.classData.values.address);
 		}
 
 		this._url = new URL(`${protocol}://${host}${path}`);

--- a/src/charles-parser.ts
+++ b/src/charles-parser.ts
@@ -241,6 +241,7 @@ export class CharlesHTTPResponse {
 
 export class CharlesHTTPTransaction {
 	private _url!: URL;
+	private _protocolVersion = 'HTTP/1.1';
 	private _clientLocalPort!: number;
 	private _clientProxyPort!: number;
 	private _serverLocalPort!: number;
@@ -252,6 +253,10 @@ export class CharlesHTTPTransaction {
 	// * Public getters
 	public get url(): URL {
 		return this._url;
+	}
+
+	public get protocolVersion(): string {
+		return this._protocolVersion;
 	}
 
 	public get clientLocalPort(): number {
@@ -296,6 +301,10 @@ export class CharlesHTTPTransaction {
 		if (transactionJSON.description.classData.values.file) {
 			// * `file` contains the query string too
 			path = transactionJSON.description.classData.values.file.value;
+		}
+
+		if (transactionJSON.description.classData.values.protocolVersion) {
+			this._protocolVersion = transactionJSON.description.classData.values.protocolVersion.value;
 		}
 
 		this._url = new URL(`${protocol}://${host}${path}`);

--- a/src/charles-zip-parser.ts
+++ b/src/charles-zip-parser.ts
@@ -101,11 +101,16 @@ export class CharlesWebSocketMessage {
 
 // TODO - Make this more generic so it can be shared with CharlesParser?
 export class CharlesHTTPRequest {
+	private _startLine!: string;
 	private _method!: 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE';
 	private _headers: { key: string; value: string }[] = [];
 	private _body?: Buffer;
 
 	// * Public getters
+	public get startLine(): string {
+		return this._startLine;
+	}
+
 	public get method(): 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' {
 		return this._method;
 	}
@@ -119,9 +124,10 @@ export class CharlesHTTPRequest {
 	}
 
 	constructor(group: any) {
+		this._startLine = group.metadata.request.header.firstLine;
 		this._method = group.metadata.method;
 
-		for (const header of group.metadata.response.header.headers) {
+		for (const header of group.metadata.request.header.headers) {
 			this._headers.push({
 				key: header.name,
 				value: header.value
@@ -136,11 +142,16 @@ export class CharlesHTTPRequest {
 
 // TODO - Make this more generic so it can be shared with CharlesParser?
 export class CharlesHTTPResponse {
+	private _startLine!: string;
 	private _status!: number;
 	private _headers: { key: string; value: string }[] = [];
 	private _body?: Buffer;
 
 	// * Public getters
+	public get startLine(): string {
+		return this._startLine;
+	}
+
 	public get status(): number {
 		return this._status;
 	}
@@ -154,6 +165,7 @@ export class CharlesHTTPResponse {
 	}
 
 	constructor(group: any) {
+		this._startLine = group.metadata.response.header.firstLine;
 		this._status = Number(group.metadata.response.status);
 
 		for (const header of group.metadata.response.header.headers) {
@@ -171,6 +183,8 @@ export class CharlesHTTPResponse {
 
 export class CharlesHTTPTransaction {
 	private _url!: URL;
+	private _protocolVersion = 'HTTP/1.1';
+	private _clientAddress = 'unknown';
 	private _clientLocalPort!: number;
 	private _clientProxyPort!: number;
 	private _serverLocalPort!: number;
@@ -182,6 +196,14 @@ export class CharlesHTTPTransaction {
 	// * Public getters
 	public get url(): URL {
 		return this._url;
+	}
+
+	public get protocolVersion(): string {
+		return this._protocolVersion;
+	}
+
+	public get clientAddress(): string {
+		return this._clientAddress;
 	}
 
 	public get clientLocalPort(): number {
@@ -213,7 +235,12 @@ export class CharlesHTTPTransaction {
 	}
 
 	constructor(group: any) {
-		this._url = new URL(`${group.metadata.scheme}://${group.metadata.host}${group.metadata.path}`);
+		this._protocolVersion = group.metadata.protocolVersion;
+		this._clientAddress = group.metadata.clientAddress.split('/').pop() || 'unknown';
+
+		const query = group.metadata.query ? `?${group.metadata.query}` : '';
+
+		this._url = new URL(`${group.metadata.scheme}://${group.metadata.host}${group.metadata.path}${query}`);
 		this._clientLocalPort = group.metadata.clientPort;
 		this._clientProxyPort = group.metadata.clientLocalPort;
 		this._serverLocalPort = group.metadata.remoteLocalPort;

--- a/src/electron/main/index.ts
+++ b/src/electron/main/index.ts
@@ -90,6 +90,18 @@ function createWindow(): void {
 		}
 	});
 
+	ipcMain.on('saveBytes', async (_, name: string, bytes: Uint8Array) => {
+		const savePath = await dialog.showSaveDialog(window, {
+			title: 'Save Body',
+			defaultPath: name,
+			properties: ['createDirectory', 'showOverwriteConfirmation']
+		});
+
+		if (!savePath.canceled && savePath.filePath) {
+			writeFileSync(savePath.filePath, Buffer.from(bytes));
+		}
+	});
+
 	window.webContents.on('will-navigate', (event) => {
 		event.preventDefault();
 	});

--- a/src/electron/main/menu.ts
+++ b/src/electron/main/menu.ts
@@ -51,6 +51,7 @@ export async function selectSessionFile(browserWindow: BrowserWindow, state: Sta
 					'chls', 'chlz',
 					'flows', 'flow',
 					'bin',
+					'har',
 					'pnsj'
 				]
 			}

--- a/src/electron/preload/index.ts
+++ b/src/electron/preload/index.ts
@@ -19,6 +19,7 @@ const api = {
 	openSelectSession: (): void => ipcRenderer.send('openSelectSession'),
 	openSession: (path: string): void => ipcRenderer.send('openSession', path),
 	exportSession: (packets: SerializedMessage[]): void => ipcRenderer.send('exportSession', packets),
+	saveBytes: (name: string, bytes: Uint8Array): void => ipcRenderer.send('saveBytes', name, bytes),
 	getPathForFile: (file: File): string => webUtils.getPathForFile(file)
 };
 

--- a/src/electron/renderer/src/assets/js/global.d.ts
+++ b/src/electron/renderer/src/assets/js/global.d.ts
@@ -19,6 +19,7 @@ declare global {
 			openSelectSession: () => void;
 			openSession: (path: string) => void;
 			exportSession: (packets: SerializedMessage[]) => void;
+			saveBytes: (name: string, bytes: Uint8Array) => void;
 			getPathForFile: (file: File) => string;
 		};
 	}

--- a/src/electron/renderer/src/components/ImageViewer.vue
+++ b/src/electron/renderer/src/components/ImageViewer.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { ref, watch, onBeforeUnmount } from 'vue';
+
+const props = defineProps<{
+	bytes: number[];
+	type: string;
+}>();
+
+const url = ref('');
+const width = ref(0);
+const height = ref(0);
+
+function revoke(): void {
+	if (url.value) {
+		URL.revokeObjectURL(url.value);
+	}
+}
+
+function load(): void {
+	revoke();
+
+	url.value = URL.createObjectURL(new Blob([new Uint8Array(props.bytes)], {
+		type: props.type
+	}));
+}
+
+function onLoad(event: Event): void {
+	const image = event.target as HTMLImageElement;
+
+	width.value = image.naturalWidth;
+	height.value = image.naturalHeight;
+}
+
+watch(() => props.bytes, load, {
+	immediate: true
+});
+
+onBeforeUnmount(revoke);
+</script>
+
+<template>
+	<div>
+		<div v-if="width !== 0" class="text-xs text-[#9a9fa9] mt-1 mb-1">{{ width }} x {{ height }} ({{ type }})</div>
+		<div class="rounded-md border border-[#2e3238] bg-[#121720] flex items-center justify-center p-2 overflow-hidden">
+			<img :src="url" draggable="false" class="max-w-full max-h-[480px] object-contain" @load="onLoad">
+		</div>
+	</div>
+</template>

--- a/src/electron/renderer/src/components/MonacoViewer.vue
+++ b/src/electron/renderer/src/components/MonacoViewer.vue
@@ -9,6 +9,12 @@ const MAX_HEIGHT = 480;
 
 // * Monaco only ships with formatters for JSON, HTML and CSS. We have to add everything else ourselves
 const FORMATTABLE_LANGUAGES = ['json', 'html', 'css'];
+const LANGUAGES = monaco.languages.getLanguages()
+	.map(language => ({
+		id: language.id,
+		label: language.aliases?.[0] ?? language.id
+	}))
+	.sort((a, b) => a.label.localeCompare(b.label));
 
 monaco.editor.defineTheme('network-viewer', {
 	base: 'vs-dark',
@@ -28,7 +34,9 @@ const container = ref<HTMLElement | null>(null);
 const editor = shallowRef<monaco.editor.IStandaloneCodeEditor | null>(null);
 const height = ref(MIN_HEIGHT);
 const formatted = ref(false);
-const canFormat = computed(() => FORMATTABLE_LANGUAGES.includes(props.language));
+
+const activeLanguage = ref(props.language);
+const canFormat = computed(() => FORMATTABLE_LANGUAGES.includes(activeLanguage.value));
 
 async function showFormatted(): Promise<void> {
 	const instance = editor.value;
@@ -96,15 +104,19 @@ onMounted(() => {
 });
 
 watch(() => [props.value, props.language], () => {
+	activeLanguage.value = props.language;
+	showRaw();
+});
+
+watch(activeLanguage, (language) => {
 	const model = editor.value?.getModel();
 
 	if (!model) {
 		return;
 	}
 
-	model.setValue(props.value);
-	monaco.editor.setModelLanguage(model, props.language);
-	formatted.value = false;
+	monaco.editor.setModelLanguage(model, language);
+	showRaw();
 });
 
 onBeforeUnmount(() => {
@@ -115,9 +127,14 @@ onBeforeUnmount(() => {
 
 <template>
 	<div>
-		<div v-if="canFormat" class="flex items-center gap-3 mb-2">
-			<button class="text-xs transition-colors cursor-pointer" :class="formatted ? 'text-[#9a9fa9] hover:text-[#F9FAFC]' : 'text-blue-400'" @click="showRaw">Raw</button>
-			<button class="text-xs transition-colors cursor-pointer" :class="formatted ? 'text-blue-400' : 'text-[#9a9fa9] hover:text-[#F9FAFC]'" @click="showFormatted">Formatted</button>
+		<div class="flex items-center gap-3 mb-2">
+			<select v-model="activeLanguage" class="bg-[#121720] border border-[#2e3238] rounded-md px-2 py-1 text-xs text-[#F9FAFC] focus:outline-none cursor-pointer">
+				<option v-for="option in LANGUAGES" :key="option.id" :value="option.id">{{ option.label }}</option>
+			</select>
+			<template v-if="canFormat">
+				<button class="text-xs transition-colors cursor-pointer" :class="formatted ? 'text-[#9a9fa9] hover:text-[#F9FAFC]' : 'text-blue-400'" @click="showRaw">Raw</button>
+				<button class="text-xs transition-colors cursor-pointer" :class="formatted ? 'text-blue-400' : 'text-[#9a9fa9] hover:text-[#F9FAFC]'" @click="showFormatted">Formatted</button>
+			</template>
 		</div>
 		<div ref="container" class="rounded-md border border-[#2e3238] overflow-hidden" :style="{ height: `${height}px` }" />
 	</div>

--- a/src/electron/renderer/src/components/MonacoViewer.vue
+++ b/src/electron/renderer/src/components/MonacoViewer.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { ref, shallowRef, watch, onMounted, onBeforeUnmount } from 'vue';
+import * as monaco from 'monaco-editor/editor';
+import 'monaco-editor/features/register.all';
+import 'monaco-editor/languages/register.all';
+
+const MIN_HEIGHT = 80;
+const MAX_HEIGHT = 480;
+
+monaco.editor.defineTheme('network-viewer', {
+	base: 'vs-dark',
+	inherit: true,
+	rules: [],
+	colors: {
+		'editor.background': '#121720'
+	}
+});
+
+const props = defineProps<{
+	value: string;
+	language: string;
+}>();
+
+const container = ref<HTMLElement | null>(null);
+const editor = shallowRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+const height = ref(MIN_HEIGHT);
+
+onMounted(() => {
+	if (!container.value) {
+		return;
+	}
+
+	// * Disable as much editor functionality as possible. We only care about viewing text in a pretty way
+	const instance = monaco.editor.create(container.value, {
+		value: props.value,
+		language: props.language,
+		theme: 'network-viewer',
+		readOnly: true,
+		domReadOnly: true,
+		contextmenu: false,
+		renderLineHighlight: 'none',
+		occurrencesHighlight: 'off',
+		selectionHighlight: false,
+		matchBrackets: 'never',
+		minimap: {
+			enabled: false
+		},
+		overviewRulerLanes: 0,
+		overviewRulerBorder: false,
+		hideCursorInOverviewRuler: true,
+		scrollBeyondLastLine: false,
+		automaticLayout: true,
+		fontSize: 12,
+		lineNumbersMinChars: 3,
+		padding: {
+			top: 8,
+			bottom: 8
+		},
+		scrollbar: {
+			alwaysConsumeMouseWheel: false
+		}
+	});
+
+	instance.onDidContentSizeChange(() => {
+		height.value = Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, instance.getContentHeight()));
+	});
+
+	editor.value = instance;
+});
+
+watch(() => [props.value, props.language], () => {
+	const model = editor.value?.getModel();
+
+	if (!model) {
+		return;
+	}
+
+	model.setValue(props.value);
+	monaco.editor.setModelLanguage(model, props.language);
+});
+
+onBeforeUnmount(() => {
+	editor.value?.getModel()?.dispose();
+	editor.value?.dispose();
+});
+</script>
+
+<template>
+	<div ref="container" class="rounded-md border border-[#2e3238] overflow-hidden" :style="{ height: `${height}px` }" />
+</template>

--- a/src/electron/renderer/src/components/MonacoViewer.vue
+++ b/src/electron/renderer/src/components/MonacoViewer.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { ref, shallowRef, watch, onMounted, onBeforeUnmount } from 'vue';
+import { ref, shallowRef, computed, watch, onMounted, onBeforeUnmount } from 'vue';
 import * as monaco from 'monaco-editor/editor';
 import 'monaco-editor/features/register.all';
 import 'monaco-editor/languages/register.all';
 
 const MIN_HEIGHT = 80;
 const MAX_HEIGHT = 480;
+
+// * Monaco only ships with formatters for JSON, HTML and CSS. We have to add everything else ourselves
+const FORMATTABLE_LANGUAGES = ['json', 'html', 'css'];
 
 monaco.editor.defineTheme('network-viewer', {
 	base: 'vs-dark',
@@ -24,6 +27,30 @@ const props = defineProps<{
 const container = ref<HTMLElement | null>(null);
 const editor = shallowRef<monaco.editor.IStandaloneCodeEditor | null>(null);
 const height = ref(MIN_HEIGHT);
+const formatted = ref(false);
+const canFormat = computed(() => FORMATTABLE_LANGUAGES.includes(props.language));
+
+async function showFormatted(): Promise<void> {
+	const instance = editor.value;
+
+	if (!instance) {
+		return;
+	}
+
+	// * Monaco needs the editor to be writeable to format it, so toggle it.
+	// * This DOES create a bit of a race condition where the user COULD modify
+	// * the contents while the formatting is happening, but idrc tbh
+	instance.updateOptions({ readOnly: false });
+	await instance.getAction('editor.action.formatDocument')?.run();
+	instance.updateOptions({ readOnly: true });
+
+	formatted.value = true;
+}
+
+function showRaw(): void {
+	editor.value?.getModel()?.setValue(props.value);
+	formatted.value = false;
+}
 
 onMounted(() => {
 	if (!container.value) {
@@ -77,6 +104,7 @@ watch(() => [props.value, props.language], () => {
 
 	model.setValue(props.value);
 	monaco.editor.setModelLanguage(model, props.language);
+	formatted.value = false;
 });
 
 onBeforeUnmount(() => {
@@ -86,5 +114,11 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-	<div ref="container" class="rounded-md border border-[#2e3238] overflow-hidden" :style="{ height: `${height}px` }" />
+	<div>
+		<div v-if="canFormat" class="flex items-center gap-3 mb-2">
+			<button class="text-xs transition-colors cursor-pointer" :class="formatted ? 'text-[#9a9fa9] hover:text-[#F9FAFC]' : 'text-blue-400'" @click="showRaw">Raw</button>
+			<button class="text-xs transition-colors cursor-pointer" :class="formatted ? 'text-blue-400' : 'text-[#9a9fa9] hover:text-[#F9FAFC]'" @click="showFormatted">Formatted</button>
+		</div>
+		<div ref="container" class="rounded-md border border-[#2e3238] overflow-hidden" :style="{ height: `${height}px` }" />
+	</div>
 </template>

--- a/src/electron/renderer/src/components/PacketDetails.vue
+++ b/src/electron/renderer/src/components/PacketDetails.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
 import SerializedField from '@renderer/components/SerializedField.vue';
+import MonacoViewer from '@renderer/components/MonacoViewer.vue';
 import { useClipboard } from '@renderer/composables/useClipboard';
 import { toHexString } from '@renderer/assets/js/util';
 import type { SerializedMessage } from '@/types/serialized-message';
@@ -108,7 +109,13 @@ watch(() => props.packet, () => {
 						<div v-if="tab.subtitle" class="text-sm text-[#9a9fa9]">{{ tab.subtitle }}</div>
 					</div>
 					<div class="space-y-1">
-						<SerializedField v-for="field in tab.fields" :key="field.name" :field-key="field.name" :field="field.data" :depth="0" />
+						<template v-for="field in tab.fields" :key="field.name">
+							<div v-if="field.language" class="mt-6 mb-2">
+								<div class="text-sm font-medium text-[#F9FAFC] mb-2">{{ field.name }}</div>
+								<MonacoViewer :value="String(field.data.__value)" :language="field.language" />
+							</div>
+							<SerializedField v-else :field-key="field.name" :field="field.data" :depth="0" />
+						</template>
 					</div>
 				</div>
 

--- a/src/electron/renderer/src/components/PacketDetails.vue
+++ b/src/electron/renderer/src/components/PacketDetails.vue
@@ -2,6 +2,7 @@
 import { ref, computed, watch } from 'vue';
 import SerializedField from '@renderer/components/SerializedField.vue';
 import MonacoViewer from '@renderer/components/MonacoViewer.vue';
+import ImageViewer from '@renderer/components/ImageViewer.vue';
 import { useClipboard } from '@renderer/composables/useClipboard';
 import { toHexString } from '@renderer/assets/js/util';
 import type { SerializedMessage } from '@/types/serialized-message';
@@ -118,12 +119,13 @@ watch(() => props.packet, () => {
 					</div>
 					<div class="space-y-1">
 						<template v-for="field in tab.fields" :key="field.name">
-							<div v-if="field.language" class="mt-6 mb-2">
+							<div v-if="field.language || field.image" class="mt-6 mb-2">
 								<div class="flex items-center gap-2 mb-2">
 									<div class="text-sm font-medium text-[#F9FAFC]">{{ field.name }}</div>
 									<button v-if="field.bytes?.length" class="text-xs text-[#9a9fa9] hover:text-[#F9FAFC] transition-colors cursor-pointer" @click="saveBytes(tab.title, field)">Save to disk</button>
 								</div>
-								<MonacoViewer :value="String(field.data.__value)" :language="field.language" />
+								<ImageViewer v-if="field.image" :bytes="field.bytes ?? []" :type="field.image" />
+								<MonacoViewer v-else :value="String(field.data.__value)" :language="field.language ?? 'plaintext'" />
 							</div>
 							<SerializedField v-else :field-key="field.name" :field="field.data" :depth="0" />
 						</template>

--- a/src/electron/renderer/src/components/PacketDetails.vue
+++ b/src/electron/renderer/src/components/PacketDetails.vue
@@ -55,7 +55,10 @@ const tabs = computed(() => {
 });
 
 watch(() => props.packet, () => {
-	activeTab.value = 'overview';
+	// * Automatically open the same tab in the new packet if it exists in the previous one
+	if (!tabs.value.some(tab => tab.id === activeTab.value)) {
+		activeTab.value = 'overview';
+	}
 });
 </script>
 

--- a/src/electron/renderer/src/components/PacketDetails.vue
+++ b/src/electron/renderer/src/components/PacketDetails.vue
@@ -14,6 +14,14 @@ const props = defineProps<{
 
 const activeTab = ref('overview');
 
+function saveBytes(tabTitle: string, field: { name: string; bytes?: number[] }): void {
+	if (!field.bytes) {
+		return;
+	}
+
+	window.api.saveBytes(`${tabTitle}-${field.name}`.toLowerCase(), new Uint8Array(field.bytes));
+}
+
 const tabs = computed(() => {
 	const t = [
 		{
@@ -111,7 +119,10 @@ watch(() => props.packet, () => {
 					<div class="space-y-1">
 						<template v-for="field in tab.fields" :key="field.name">
 							<div v-if="field.language" class="mt-6 mb-2">
-								<div class="text-sm font-medium text-[#F9FAFC] mb-2">{{ field.name }}</div>
+								<div class="flex items-center gap-2 mb-2">
+									<div class="text-sm font-medium text-[#F9FAFC]">{{ field.name }}</div>
+									<button v-if="field.bytes?.length" class="text-xs text-[#9a9fa9] hover:text-[#F9FAFC] transition-colors cursor-pointer" @click="saveBytes(tab.title, field)">Save to disk</button>
+								</div>
 								<MonacoViewer :value="String(field.data.__value)" :language="field.language" />
 							</div>
 							<SerializedField v-else :field-key="field.name" :field="field.data" :depth="0" />

--- a/src/electron/renderer/src/components/SerializedField.vue
+++ b/src/electron/renderer/src/components/SerializedField.vue
@@ -102,6 +102,17 @@ function getDisplayValue(field: SerializedField): string {
 	return `${field.__value}`;
 }
 
+// * Only currently used to save HTTP form file uploads
+function saveValue(field: SerializedField): void {
+	const bytes = field.__bytes ?? (Array.isArray(field.__value) ? field.__value : undefined);
+
+	if (!bytes) {
+		return;
+	}
+
+	window.api.saveBytes(field.__filename ?? props.fieldKey, new Uint8Array(bytes));
+}
+
 function copyValue(e: MouseEvent, field: SerializedField): void {
 	if (field.__typeName === 'Buffer' || field.__typeName === 'QBuffer') {
 		copyToClipboard(e, toHexString(field.__value));
@@ -252,6 +263,7 @@ const variantIsComplex = variantInner && ('__fields' in variantInner || (typeof 
 		<div class="ml-2 flex-1 truncate">
 			<span class="text-sm cursor-pointer hover:underline" @click="copyValue($event, field)">{{ getDisplayValue(field) }}</span>
 		</div>
+		<button v-if="field.__saveable" class="ml-2 flex-shrink-0 text-xs text-[#9a9fa9] hover:text-[#F9FAFC] transition-colors cursor-pointer" @click="saveValue(field)">Save to disk</button>
 	</div>
 
 	<AccordionRoot v-else class="w-full" type="single" :collapsible="true">

--- a/src/flows-parser.ts
+++ b/src/flows-parser.ts
@@ -64,6 +64,7 @@ type FlowConnection = {
 	timestamp_tls_setup: number | null;
 };
 interface FlowClientConnection extends FlowConnection {
+	address: Address | null;
 	peername: Address;
 	sockname: Address;
 	mitmcert: Cert | null;
@@ -172,6 +173,7 @@ export default class FlowsParser {
 			throw new Error('Expected dictionary node');
 		}
 
+		// TODO - Transparent mode (when the proxy doesn't intercept HTTPS data) will include 'tcp' nodes
 		if (tnetstring.type !== 'http') {
 			throw new Error('Expected http flow');
 		}
@@ -184,6 +186,13 @@ export default class FlowsParser {
 			flow.client_conn.peername = {
 				ip: flowData.client_conn.peername[0],
 				port: flowData.client_conn.peername[1]
+			};
+		}
+
+		if (flowData.client_conn.address) {
+			flow.client_conn.peername = {
+				ip: flowData.client_conn.address[0],
+				port: flowData.client_conn.address[1]
 			};
 		}
 

--- a/src/flows-parser.ts
+++ b/src/flows-parser.ts
@@ -11,7 +11,7 @@ type Address = {
 type Cert = Buffer;
 type FlowMessageData = {
 	http_version: Buffer;
-	headers: Record<string, string>; // * Not accurate, this is encoded as a tuple of `(key, value)`
+	headers: string[][]; // * Encoded as a tuple of `(key, value)`
 	content: Buffer | null;
 	trailers: Record<string, string> | null; // * Not accurate, this is encoded as a tuple of `(key, value)`
 	timestamp_start: number;
@@ -130,7 +130,7 @@ type _Flow = {
 	backup: _Flow | null;
 };
 
-interface HTTPFlow extends _Flow {
+export interface HTTPFlow extends _Flow {
 	type: 'http';
 	request: FlowRequest;
 	response: FlowResponse | null;
@@ -226,14 +226,14 @@ export default class FlowsParser {
 		}
 
 		if (flow.type === 'http') {
-			flow.request.headers = Object.fromEntries(flowData.request.headers.map(([key, value]: any[]) => [key.toString(), value.toString()]));
+			flow.request.headers = flowData.request.headers.map(([key, value]: any[]) => [key.toString(), value.toString()]);
 
 			if (flowData.request.trailers) {
 				flow.request.trailers = Object.fromEntries(flowData.request.trailers.map(([key, value]: any[]) => [key.toString(), value.toString()]));
 			}
 
 			if (flowData.response) {
-				flow.response!.headers = Object.fromEntries(flowData.response.headers.map(([key, value]: any[]) => [key.toString(), value.toString()]));
+				flow.response!.headers = flowData.response.headers.map(([key, value]: any[]) => [key.toString(), value.toString()]);
 
 				if (flowData.response.trailers) {
 					flow.response!.trailers = Object.fromEntries(flowData.response.trailers.map(([key, value]: any[]) => [key.toString(), value.toString()]));

--- a/src/har-parser.ts
+++ b/src/har-parser.ts
@@ -1,0 +1,349 @@
+// TODO - Move these types to the `@/types` folder like the rest of the types once well-defined
+// * Using http://www.softwareishard.com/blog/har-12-spec/ as the spec since
+// * https://w3c.github.io/web-performance/specs/HAR/Overview.html says to not be used? The
+// * softwareishard source comes from https://en.wikipedia.org/wiki/HAR_(file_format)
+
+export interface HARCreator {
+	name: string;
+	version: string;
+	comment?: string;
+}
+
+export interface HARBrowser {
+	name: string;
+	version: string;
+	comment?: string;
+}
+
+export interface HARPageTimings {
+	onContentLoad?: number;
+	onLoad?: number;
+	comment?: string;
+}
+
+export interface HARPage {
+	startedDateTime: string;
+	id: string;
+	title: string;
+	pageTimings: HARPageTimings;
+	comment?: string;
+}
+
+export interface HARCookie {
+	name: string;
+	value: string;
+	path?: string;
+	domain?: string;
+	expires?: string;
+	httpOnly?: boolean;
+	secure?: boolean;
+	comment?: string;
+}
+
+export interface HARHeader {
+	name: string;
+	value: string;
+	comment?: string;
+}
+
+export interface HARQueryStringParam {
+	name: string;
+	value: string;
+	comment?: string;
+}
+
+export interface HARParam {
+	name: string;
+	value?: string;
+	fileName?: string;
+	contentType?: string;
+	comment?: string;
+}
+
+export interface HARPostData {
+	mimeType: string;
+	params?: HARParam[]; // * `text` and `params` are mutually exclusive
+	text?: string; // * `text` and `params` are mutually exclusive
+	comment?: string;
+}
+
+export interface HARContent {
+	size: number;
+	compression?: number;
+	mimeType: string;
+	text?: string;
+	encoding?: string; // * Encoding used for response text field e.g "base64". Leave out this field if the text field is HTTP decoded (decompressed & unchunked), than trans-coded from its original character set into UTF-8
+	comment?: string;
+}
+
+export interface HARRequest {
+	method: string;
+	url: string;
+	httpVersion: string;
+	cookies: HARCookie[];
+	headers: HARHeader[];
+	queryString: HARQueryStringParam[];
+	postData?: HARPostData;
+	headersSize: number; // * -1 when not available
+	bodySize: number; // * -1 when not available
+	comment?: string;
+}
+
+export interface HARResponse {
+	status: number;
+	statusText: string;
+	httpVersion: string;
+	cookies: HARCookie[];
+	headers: HARHeader[];
+	content: HARContent;
+	redirectURL: string;
+	headersSize: number; // * -1 when not available
+	bodySize: number; // * 0 for cached responses, -1 when not available
+	comment?: string;
+}
+
+export interface HARCacheEntry {
+	expires?: string;
+	lastAccess: string;
+	eTag: string;
+	hitCount: number;
+	comment?: string;
+}
+
+export interface HARCache {
+	beforeRequest?: HARCacheEntry | null;
+	afterRequest?: HARCacheEntry | null;
+	comment?: string;
+}
+
+// * Fields have a value of -1 when the timing doesn't apply
+export interface HARTimings {
+	blocked?: number;
+	dns?: number;
+	connect?: number;
+	send: number;
+	wait: number;
+	receive: number;
+	ssl?: number; // * Same as `connect` for 1.1 compatibility
+	comment?: string;
+}
+
+export interface HAREntry {
+	pageref?: string;
+	startedDateTime: string; // * ISO 8601
+	time: number; // * Milliseconds
+	request: HARRequest;
+	response: HARResponse;
+	cache: HARCache;
+	timings: HARTimings;
+	serverIPAddress?: string;
+	connection?: string;
+	comment?: string;
+}
+
+export interface HARLog {
+	version: string; // * "1.1" is assumed when empty
+	creator: HARCreator;
+	browser?: HARBrowser;
+	pages?: HARPage[];
+	entries: HAREntry[];
+	comment?: string;
+}
+
+export interface HARFile {
+	log: HARLog;
+}
+
+function headersToPairs(headers: HARHeader[]): { key: string; value: string }[] {
+	return headers.map(header => ({
+		key: header.name,
+		value: header.value
+	}));
+}
+
+export default class HARParser {
+	private buffer: Buffer;
+	private _log!: HARLog;
+
+	constructor(buffer: Buffer) {
+		this.buffer = buffer;
+
+		this.parse();
+	}
+
+	private parse(): void {
+		const har: HARFile = JSON.parse(this.buffer.toString());
+
+		if (!har.log || !Array.isArray(har.log.entries)) {
+			throw new Error('Invalid HAR file. Expected a log with entries');
+		}
+
+		this._log = har.log;
+	}
+
+	public* transactions(): Generator<HARHTTPTransaction> {
+		for (const entry of this._log.entries) {
+			yield new HARHTTPTransaction(entry);
+		}
+	}
+}
+
+export class HARHTTPRequest {
+	private _startLine!: string;
+	private _method!: string;
+	private _headers: { key: string; value: string }[] = [];
+	private _cookies: HARCookie[] = [];
+	private _queryString: HARQueryStringParam[] = [];
+	private _params: HARParam[] = [];
+	private _body?: Buffer;
+
+	// * Public getters
+	public get startLine(): string {
+		return this._startLine;
+	}
+
+	public get method(): string {
+		return this._method;
+	}
+
+	public get headers(): { key: string; value: string }[] {
+		return this._headers;
+	}
+
+	public get cookies(): HARCookie[] {
+		return this._cookies;
+	}
+
+	public get queryString(): HARQueryStringParam[] {
+		return this._queryString;
+	}
+
+	public get params(): HARParam[] {
+		return this._params;
+	}
+
+	public get body(): Buffer | undefined {
+		return this._body;
+	}
+
+	constructor(entry: HAREntry) {
+		const request = entry.request;
+
+		this._method = request.method;
+		this._headers = headersToPairs(request.headers);
+		this._cookies = request.cookies ?? [];
+		this._queryString = request.queryString ?? [];
+		this._params = request.postData?.params ?? [];
+
+		// * When a body was posted as `params` rather than `text` there are no original bytes to hand back
+		// TODO - Figure this out
+		if (request.postData?.text !== undefined) {
+			this._body = Buffer.from(request.postData.text);
+		}
+
+		const url = new URL(request.url);
+
+		this._startLine = `${request.method} ${url.pathname}${url.search} ${request.httpVersion}`;
+	}
+}
+
+export class HARHTTPResponse {
+	private _startLine!: string;
+	private _status!: number;
+	private _statusText!: string;
+	private _headers: { key: string; value: string }[] = [];
+	private _cookies: HARCookie[] = [];
+	private _body?: Buffer;
+
+	// * Public getters
+	public get startLine(): string {
+		return this._startLine;
+	}
+
+	public get status(): number {
+		return this._status;
+	}
+
+	public get statusText(): string {
+		return this._statusText;
+	}
+
+	public get headers(): { key: string; value: string }[] {
+		return this._headers;
+	}
+
+	public get cookies(): HARCookie[] {
+		return this._cookies;
+	}
+
+	public get body(): Buffer | undefined {
+		return this._body;
+	}
+
+	constructor(entry: HAREntry) {
+		const response = entry.response;
+		const content = response.content;
+
+		this._status = response.status;
+		this._statusText = response.statusText;
+		this._headers = headersToPairs(response.headers);
+		this._cookies = response.cookies ?? [];
+
+		// TODO - Support other encodings if they exist
+		if (content?.text !== undefined) {
+			this._body = content.encoding === 'base64' ? Buffer.from(content.text, 'base64') : Buffer.from(content.text);
+		}
+
+		this._startLine = `${response.httpVersion} ${response.status} ${response.statusText}`.trim();
+	}
+}
+
+export class HARHTTPTransaction {
+	private _url!: URL;
+	private _serverAddress?: string;
+	private _connection?: string;
+	private _startTime!: number;
+	private _duration!: number;
+	private _request!: HARHTTPRequest;
+	private _response!: HARHTTPResponse;
+
+	// * Public getters
+	public get url(): URL {
+		return this._url;
+	}
+
+	public get serverAddress(): string | undefined {
+		return this._serverAddress;
+	}
+
+	public get connection(): string | undefined {
+		return this._connection;
+	}
+
+	// * Converted to seconds already
+	public get startTime(): number {
+		return this._startTime;
+	}
+
+	public get duration(): number {
+		return this._duration;
+	}
+
+	public get request(): HARHTTPRequest {
+		return this._request;
+	}
+
+	public get response(): HARHTTPResponse {
+		return this._response;
+	}
+
+	constructor(entry: HAREntry) {
+		this._url = new URL(entry.request.url);
+		this._serverAddress = entry.serverIPAddress;
+		this._connection = entry.connection;
+		this._startTime = Date.parse(entry.startedDateTime) / 1000;
+		this._duration = entry.time / 1000;
+		this._request = new HARHTTPRequest(entry);
+		this._response = new HARHTTPResponse(entry);
+	}
+}

--- a/src/http-message.ts
+++ b/src/http-message.ts
@@ -213,14 +213,11 @@ export class HTTPRequest extends HTTPMessageBase {
 		this.protocol = protocol;
 		this.hostname = this.header('host');
 
-		if (this.requestTarget.includes('?')) {
-			const [path, query] = this.requestTarget.split('?');
+		// * Only the first "?" separates the path from the query, any others are part of the query itself
+		const [path, ...query] = this.requestTarget.split('?');
 
-			this.path = path;
-			this.query = new URLSearchParams(query);
-		} else {
-			this.path = this.requestTarget;
-		}
+		this.path = path;
+		this.query = new URLSearchParams(query.join('?'));
 	}
 }
 

--- a/src/http-message.ts
+++ b/src/http-message.ts
@@ -36,39 +36,45 @@ abstract class HTTPMessageBase {
 				const encodings = contentEncodingsHeaders.split(',').map(encoding => encoding.trim().toLowerCase()).filter(encoding => encoding).reverse() as ContentEncoding[];
 				let decompressed = this.body;
 
-				for (const encoding of encodings) {
-					switch (encoding) {
-						case 'gzip':
-						case 'x-gzip': // * Legacy name
-							decompressed = zlib.gunzipSync(decompressed);
-							break;
-						case 'compress':
-						case 'x-compress': // * Legacy name
-							// TODO - I couldn't find a web server that gave a sample of this to verify if it worked
-							console.warn('HTTP message using the compress/x-compress content encoding. This encoding format is not yet supported');
-							break;
-						case 'deflate':
-							// TODO - I couldn't find a web server that gave a sample of this to verify if it worked
-							console.warn('HTTP message using the deflate content encoding. This encoding format is not yet supported');
-							break;
-						case 'br':
-							decompressed = zlib.brotliDecompressSync(decompressed);
-							break;
-						case 'zstd':
-							decompressed = zlib.zstdDecompressSync(decompressed);
-							break;
-						case 'dcb':
-							// TODO - This requires knowledge of an external dictionary, and this class is stateless so it doesn't have access to that. Maybe add this later
-							console.warn('HTTP message using the dcb content encoding. This encoding format is not yet supported');
-							break;
-						case 'dcz':
-							// TODO - This requires knowledge of an external dictionary, and this class is stateless so it doesn't have access to that. Maybe add this later
-							console.warn('HTTP message using the dcz content encoding. This encoding format is not yet supported');
-							break;
+				try {
+					for (const encoding of encodings) {
+						switch (encoding) {
+							case 'gzip':
+							case 'x-gzip': // * Legacy name
+								decompressed = zlib.gunzipSync(decompressed);
+								break;
+							case 'compress':
+							case 'x-compress': // * Legacy name
+								// TODO - I couldn't find a web server that gave a sample of this to verify if it worked
+								console.warn('HTTP message using the compress/x-compress content encoding. This encoding format is not yet supported');
+								break;
+							case 'deflate':
+								// TODO - I couldn't find a web server that gave a sample of this to verify if it worked
+								console.warn('HTTP message using the deflate content encoding. This encoding format is not yet supported');
+								break;
+							case 'br':
+								decompressed = zlib.brotliDecompressSync(decompressed);
+								break;
+							case 'zstd':
+								decompressed = zlib.zstdDecompressSync(decompressed);
+								break;
+							case 'dcb':
+								// TODO - This requires knowledge of an external dictionary, and this class is stateless so it doesn't have access to that. Maybe add this later
+								console.warn('HTTP message using the dcb content encoding. This encoding format is not yet supported');
+								break;
+							case 'dcz':
+								// TODO - This requires knowledge of an external dictionary, and this class is stateless so it doesn't have access to that. Maybe add this later
+								console.warn('HTTP message using the dcz content encoding. This encoding format is not yet supported');
+								break;
+						}
 					}
-				}
 
-				this.body = decompressed;
+					this.body = decompressed;
+				} catch {
+					// * Sanity check. Some dump formats like Fiddler modify the request/response bodies
+					// * so fallback to the raw bytes if anything goes wrong
+					this.body = this.bodyRaw;
+				}
 			}
 
 			const contentType = this.header('content-type');

--- a/src/http-message.ts
+++ b/src/http-message.ts
@@ -233,11 +233,12 @@ export class HTTPResponse extends HTTPMessageBase {
 	constructor(data: Buffer) {
 		super(data);
 
-		const [protocol, statusCode, reasonPhrase] = this.startLine.split(' ');
+		// * The reason phrase is optional and may contain spaces, so just assume it's everything after the status code
+		const [protocol, statusCode, ...reasonPhrase] = this.startLine.split(' ');
 
 		this.protocol = protocol;
 		this.statusCode = Number(statusCode);
-		this.reasonPhrase = reasonPhrase;
+		this.reasonPhrase = reasonPhrase.join(' ');
 	}
 }
 

--- a/src/http-message.ts
+++ b/src/http-message.ts
@@ -6,6 +6,14 @@ export enum HTTPMessageDirection {
 }
 
 type HTTPMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH' | 'QUERY';
+
+// * `FormData` holds its values as Blobs, which use an async-based API. We do everything sync
+export interface HTTPFormField {
+	name: string;
+	value: Buffer;
+	filename?: string; // * Only set when the part is a file
+	contentType?: string; // * The parts own content type, when it declared one
+}
 type ContentEncoding = 'gzip' | 'x-gzip' | 'compress' | 'x-compress' | 'deflate' | 'br' | 'zstd' | 'dcb' | 'dcz';
 
 // TODO - Add more convenience methods to the classes
@@ -15,7 +23,7 @@ abstract class HTTPMessageBase {
 	public readonly headers: string[][];
 	public readonly body: Buffer = Buffer.alloc(0);
 	public readonly bodyRaw: Buffer = Buffer.alloc(0);
-	public readonly form: FormData = new FormData();
+	public readonly form: HTTPFormField[] = [];
 
 	protected readonly startLine: string;
 
@@ -80,10 +88,11 @@ abstract class HTTPMessageBase {
 			const contentType = this.header('content-type');
 
 			if (contentType === 'application/x-www-form-urlencoded') {
-				const searchParams = new URLSearchParams(this.text());
-
-				for (const [key, value] of Object.entries(Object.fromEntries(searchParams))) {
-					this.form.append(key, value);
+				for (const [name, value] of new URLSearchParams(this.text())) {
+					this.form.push({
+						name: name,
+						value: Buffer.from(value)
+					});
 				}
 			}
 
@@ -147,25 +156,18 @@ abstract class HTTPMessageBase {
 						dispositionValues.set(name.toLowerCase(), value);
 					}
 
-					const body = chunk.subarray(metadata.bodyStart);
-					const blob = new Blob([new Uint8Array(body)]);
 					const name = dispositionValues.get('name');
-					const filename = dispositionValues.get('filename');
 
 					if (name === undefined) {
 						continue;
 					}
 
-					if (filename) {
-						const type = headers.get('content-type') ?? 'text/plain';
-						const file = new File([blob], filename, {
-							type: type
-						});
-
-						this.form.append(name, file);
-					} else {
-						this.form.append(name, blob);
-					}
+					this.form.push({
+						name: name,
+						value: chunk.subarray(metadata.bodyStart),
+						filename: dispositionValues.get('filename'),
+						contentType: headers.get('content-type')
+					});
 				}
 			}
 		}

--- a/src/http-transaction.ts
+++ b/src/http-transaction.ts
@@ -39,7 +39,8 @@ function bodyLanguage(mime: string): string {
 }
 
 function formField(field: HTTPFormField): SerializedField {
-	if (field.contentType === undefined) {
+	// * 3DS and Wii U file uploads only have the "file" field name as reference
+	if (field.contentType === undefined && field.name !== 'file') {
 		return {
 			__displayTypeName: 'String',
 			__saveable: true,
@@ -275,6 +276,7 @@ export default class HTTPTransaction {
 									name: 'Headers',
 									data: {
 										__displayTypeName: 'HTTP Headers',
+										// TODO - This doesn't support multiple headers with the same name
 										__fields: Object.fromEntries(
 											this.response.headers.map(([name, value]) => [
 												name,

--- a/src/http-transaction.ts
+++ b/src/http-transaction.ts
@@ -14,6 +14,25 @@ function buildMessage(startLine: string, headers: { key: string; value: string }
 	]);
 }
 
+// * Picks the language Monaco highlights the body with
+function bodyLanguage(message: HTTPRequest | HTTPResponse): string {
+	const mime = (message.header('content-type') ?? '').split(';')[0].trim().toLowerCase();
+
+	if (mime === 'application/json' || mime.endsWith('+json')) {
+		return 'json';
+	}
+
+	if (mime === 'application/xml' || mime === 'text/xml' || mime.endsWith('+xml')) {
+		return 'xml';
+	}
+
+	if (mime === 'text/html') {
+		return 'html';
+	}
+
+	return 'plaintext';
+}
+
 export default class HTTPTransaction {
 	public id = -1; // * Unique ID for the UI layer
 
@@ -116,7 +135,16 @@ export default class HTTPTransaction {
 									])
 								)
 							}
-						}
+						},
+						...(this.request.body.length !== 0
+							? [{
+									name: 'Body',
+									language: bodyLanguage(this.request),
+									data: {
+										__value: this.request.text()
+									}
+								}]
+							: [])
 					]
 				},
 				...(this.response !== undefined
@@ -137,7 +165,16 @@ export default class HTTPTransaction {
 											])
 										)
 									}
-								}
+								},
+								...(this.response.body.length !== 0
+									? [{
+											name: 'Body',
+											language: bodyLanguage(this.response),
+											data: {
+												__value: this.response.text()
+											}
+										}]
+									: [])
 							]
 						}]
 					: [])

--- a/src/http-transaction.ts
+++ b/src/http-transaction.ts
@@ -28,7 +28,7 @@ export default class HTTPTransaction {
 		const transaction = new HTTPTransaction();
 
 		transaction.uri = charlesTransaction.url.toString();
-		transaction.clientAddress = 'CLIENT';
+		transaction.clientAddress = charlesTransaction.clientAddress;
 		transaction.clientPort = charlesTransaction.clientLocalPort;
 		transaction.request = new HTTPRequest(buildMessage(
 			charlesTransaction.request.startLine,

--- a/src/http-transaction.ts
+++ b/src/http-transaction.ts
@@ -14,10 +14,12 @@ function buildMessage(startLine: string, headers: { key: string; value: string }
 	]);
 }
 
-// * Picks the language Monaco highlights the body with
-function bodyLanguage(message: HTTPRequest | HTTPResponse): string {
-	const mime = (message.header('content-type') ?? '').split(';')[0].trim().toLowerCase();
+function mimeType(message: HTTPRequest | HTTPResponse): string {
+	return (message.header('content-type') ?? '').split(';')[0].trim().toLowerCase();
+}
 
+// * Picks the language Monaco highlights the body with
+function bodyLanguage(mime: string): string {
 	if (mime === 'application/json' || mime.endsWith('+json')) {
 		return 'json';
 	}
@@ -69,6 +71,8 @@ export default class HTTPTransaction {
 
 	public toJSON(): SerializedMessage {
 		const url = new URL(this.uri);
+		const requestMime = mimeType(this.request);
+		const responseMime = this.response ? mimeType(this.response) : '';
 
 		return {
 			id: this.id,
@@ -139,8 +143,10 @@ export default class HTTPTransaction {
 						...(this.request.body.length !== 0
 							? [{
 									name: 'Body',
-									language: bodyLanguage(this.request),
 									bytes: [...this.request.body.values()],
+									...(requestMime.startsWith('image/')
+										? { image: requestMime }
+										: { language: bodyLanguage(requestMime) }),
 									data: {
 										__value: this.request.text()
 									}
@@ -170,8 +176,10 @@ export default class HTTPTransaction {
 								...(this.response.body.length !== 0
 									? [{
 											name: 'Body',
-											language: bodyLanguage(this.response),
 											bytes: [...this.response.body.values()],
+											...(responseMime.startsWith('image/')
+												? { image: responseMime }
+												: { language: bodyLanguage(responseMime) }),
 											data: {
 												__value: this.response.text()
 											}

--- a/src/http-transaction.ts
+++ b/src/http-transaction.ts
@@ -140,6 +140,7 @@ export default class HTTPTransaction {
 							? [{
 									name: 'Body',
 									language: bodyLanguage(this.request),
+									bytes: [...this.request.body.values()],
 									data: {
 										__value: this.request.text()
 									}
@@ -170,6 +171,7 @@ export default class HTTPTransaction {
 									? [{
 											name: 'Body',
 											language: bodyLanguage(this.response),
+											bytes: [...this.response.body.values()],
 											data: {
 												__value: this.response.text()
 											}

--- a/src/http-transaction.ts
+++ b/src/http-transaction.ts
@@ -1,0 +1,147 @@
+import { HTTPRequest, HTTPResponse } from '@/http-message';
+import type { CharlesHTTPTransaction } from '@/charles-parser';
+import type { SerializedMessage } from '@/types/serialized-message';
+
+// * Rebuild the original HTTP message to reuse the existing HTTP message parser regardless
+// * of how the transaction data was extracted from whatever dump format is being used.
+// * NOTE: THIS ASSUMES THE DATA, SUCH AS HEADERS AND STARTLINE, ARE ACCURATE TO THE ORIGINAL MESSAGE
+function buildMessage(startLine: string, headers: { key: string; value: string }[], body?: Buffer): Buffer {
+	const lines = [startLine, ...headers.map(header => `${header.key}: ${header.value}`)];
+
+	return Buffer.concat([
+		Buffer.from(`${lines.join('\r\n')}\r\n\r\n`),
+		body ?? Buffer.alloc(0)
+	]);
+}
+
+export default class HTTPTransaction {
+	public id = -1; // * Unique ID for the UI layer
+
+	public uri!: string;
+	public clientAddress!: string;
+	public clientPort!: number;
+	public elapsedTime = 0;
+	public request!: HTTPRequest;
+	public response?: HTTPResponse;
+
+	public static fromCharlesTransaction(charlesTransaction: CharlesHTTPTransaction): HTTPTransaction {
+		const transaction = new HTTPTransaction();
+
+		transaction.uri = charlesTransaction.url.toString();
+		transaction.clientAddress = 'CLIENT';
+		transaction.clientPort = charlesTransaction.clientLocalPort;
+		transaction.request = new HTTPRequest(buildMessage(
+			charlesTransaction.request.startLine,
+			charlesTransaction.request.headers,
+			charlesTransaction.request.body
+		));
+
+		// * Transactions with errors have no status
+		if (Number.isFinite(charlesTransaction.response.status)) {
+			transaction.response = new HTTPResponse(buildMessage(
+				charlesTransaction.response.startLine,
+				charlesTransaction.response.headers,
+				charlesTransaction.response.body
+			));
+		}
+
+		return transaction;
+	}
+
+	public toJSON(): SerializedMessage {
+		const url = new URL(this.uri);
+
+		return {
+			id: this.id,
+			elapsed_time: this.elapsedTime,
+			transport: 'HTTP',
+			source: `${this.clientAddress}:${this.clientPort}`,
+			destination: `${url.protocol}//${url.hostname}`,
+			destination_path: url.pathname,
+			method: this.request.method,
+			status: this.response?.statusCode,
+			overview_sections: [
+				{
+					title: 'General',
+					columns: 2,
+					fields: [
+						{
+							name: 'Elapsed Time',
+							value: this.elapsedTime.toFixed(6)
+						},
+						{
+							name: 'URL',
+							value: this.uri
+						},
+						{
+							name: 'HTTP Version',
+							value: this.request.protocol
+						},
+						...(this.response !== undefined
+							? [{
+									name: 'Status',
+									value: `${this.response.statusCode} ${this.response.reasonPhrase}`.trim()
+								}]
+							: [])
+					]
+				}
+			],
+			hex_views: [
+				{
+					title: 'Request Body',
+					bytes: [...this.request.body.values()]
+				},
+				...(this.response !== undefined
+					? [{
+							title: 'Response Body',
+							bytes: [...this.response.body.values()]
+						}]
+					: [])
+			],
+			serialized_tabs: [
+				{
+					title: 'Request',
+					fields: [
+						{
+							name: 'Headers',
+							data: {
+								__displayTypeName: 'HTTP Headers',
+								__fields: Object.fromEntries(
+									this.request.headers.map(([name, value]) => [
+										name,
+										{
+											__displayTypeName: 'String',
+											__value: value
+										}
+									])
+								)
+							}
+						}
+					]
+				},
+				...(this.response !== undefined
+					? [{
+							title: 'Response',
+							fields: [
+								{
+									name: 'Headers',
+									data: {
+										__displayTypeName: 'HTTP Headers',
+										__fields: Object.fromEntries(
+											this.response.headers.map(([name, value]) => [
+												name,
+												{
+													__displayTypeName: 'String',
+													__value: value
+												}
+											])
+										)
+									}
+								}
+							]
+						}]
+					: [])
+			]
+		};
+	}
+}

--- a/src/http-transaction.ts
+++ b/src/http-transaction.ts
@@ -1,6 +1,7 @@
 import { HTTPRequest, HTTPResponse } from '@/http-message';
+import type { HTTPFormField } from '@/http-message';
 import type { CharlesHTTPTransaction } from '@/charles-parser';
-import type { SerializedMessage } from '@/types/serialized-message';
+import type { SerializedMessage, SerializedField } from '@/types/serialized-message';
 
 // * Rebuild the original HTTP message to reuse the existing HTTP message parser regardless
 // * of how the transaction data was extracted from whatever dump format is being used.
@@ -33,6 +34,47 @@ function bodyLanguage(mime: string): string {
 	}
 
 	return 'plaintext';
+}
+
+function formField(field: HTTPFormField): SerializedField {
+	if (field.contentType === undefined) {
+		return {
+			__displayTypeName: 'String',
+			__saveable: true,
+			__bytes: [...field.value.values()],
+			__filename: field.filename ?? field.name,
+			__value: field.value.toString()
+		};
+	}
+
+	return {
+		__displayTypeName: 'File',
+		__fields: {
+			...(field.filename !== undefined
+				? {
+						filename: {
+							__displayTypeName: 'String',
+							__value: field.filename
+						}
+					}
+				: {}),
+			content_type: {
+				__displayTypeName: 'String',
+				__value: field.contentType
+			},
+			size: {
+				__displayTypeName: 'Int32',
+				__value: field.value.length
+			},
+			data: {
+				__displayTypeName: 'Buffer',
+				__typeName: 'Buffer',
+				__saveable: true,
+				__filename: field.filename ?? field.name,
+				__value: [...field.value.values()]
+			}
+		}
+	};
 }
 
 export default class HTTPTransaction {
@@ -140,6 +182,15 @@ export default class HTTPTransaction {
 								)
 							}
 						},
+						...(this.request.form.length !== 0
+							? [{
+									name: 'Form',
+									data: {
+										__displayTypeName: 'Form Data',
+										__fields: Object.fromEntries(this.request.form.map(field => [field.name, formField(field)]))
+									}
+								}]
+							: []),
 						...(this.request.body.length !== 0
 							? [{
 									name: 'Body',
@@ -173,6 +224,15 @@ export default class HTTPTransaction {
 										)
 									}
 								},
+								...(this.response.form.length !== 0
+									? [{
+											name: 'Form',
+											data: {
+												__displayTypeName: 'Form Data',
+												__fields: Object.fromEntries(this.response.form.map(field => [field.name, formField(field)]))
+											}
+										}]
+									: []),
 								...(this.response.body.length !== 0
 									? [{
 											name: 'Body',

--- a/src/http-transaction.ts
+++ b/src/http-transaction.ts
@@ -1,6 +1,7 @@
 import { HTTPRequest, HTTPResponse } from '@/http-message';
 import type { HTTPFormField } from '@/http-message';
 import type { CharlesHTTPTransaction } from '@/charles-parser';
+import type { HTTPFlow } from '@/flows-parser';
 import type { SerializedMessage, SerializedField } from '@/types/serialized-message';
 
 // * Rebuild the original HTTP message to reuse the existing HTTP message parser regardless
@@ -105,6 +106,42 @@ export default class HTTPTransaction {
 				charlesTransaction.response.startLine,
 				charlesTransaction.response.headers,
 				charlesTransaction.response.body
+			));
+		}
+
+		return transaction;
+	}
+
+	public static fromMitmproxyFlow(flow: HTTPFlow): HTTPTransaction {
+		const transaction = new HTTPTransaction();
+		const request = flow.request;
+		const headers = request.headers.map(([key, value]) => ({ key, value }));
+		const httpVersion = request.http_version.toString();
+		const method = request.method.toString();
+		const authority = request.authority.toString();
+
+		// * This info is scattered between several places depending on different contexts
+		const hostHeader = headers.find(header => header.key.toLowerCase() === 'host')?.value;
+		const host = (httpVersion === 'HTTP/2.0' || httpVersion === 'HTTP/3' ? authority || hostHeader : hostHeader) || request.host;
+		const isConnect = method === 'CONNECT';
+		const target = isConnect ? authority || `${request.host}:${request.port}` : request.path.toString();
+
+		transaction.uri = `${request.scheme.toString()}://${host}${isConnect || target === '*' ? '' : target}`;
+		transaction.clientAddress = flow.client_conn.peername.ip;
+		transaction.clientPort = flow.client_conn.peername.port;
+
+		transaction.request = new HTTPRequest(buildMessage(
+			`${method} ${target} ${httpVersion}`,
+			headers,
+			request.content ?? undefined
+		));
+
+		if (flow.response) {
+			transaction.response = new HTTPResponse(buildMessage(
+				// * mitmproxy specifically uses ISO-8859-1 here, so copying that just to be safe
+				`${flow.response.http_version.toString()} ${flow.response.status_code} ${flow.response.reason.toString('latin1')}`.trim(),
+				flow.response.headers.map(([key, value]) => ({ key, value })),
+				flow.response.content ?? undefined
 			));
 		}
 

--- a/src/http-transaction.ts
+++ b/src/http-transaction.ts
@@ -2,6 +2,7 @@ import { HTTPRequest, HTTPResponse } from '@/http-message';
 import type { HTTPFormField } from '@/http-message';
 import type { CharlesHTTPTransaction } from '@/charles-parser';
 import type { HTTPFlow } from '@/flows-parser';
+import type { HARHTTPTransaction } from '@/har-parser';
 import type { SerializedMessage, SerializedField } from '@/types/serialized-message';
 
 // * Rebuild the original HTTP message to reuse the existing HTTP message parser regardless
@@ -83,7 +84,7 @@ export default class HTTPTransaction {
 
 	public uri!: string;
 	public clientAddress!: string;
-	public clientPort!: number;
+	public clientPort?: number; // * Not every dump format has this
 	public elapsedTime = 0;
 	public request!: HTTPRequest;
 	public response?: HTTPResponse;
@@ -148,6 +149,30 @@ export default class HTTPTransaction {
 		return transaction;
 	}
 
+	public static fromHARTransaction(harTransaction: HARHTTPTransaction): HTTPTransaction {
+		const transaction = new HTTPTransaction();
+
+		transaction.uri = harTransaction.url.toString();
+
+		// * HAR dumps don't seem to store the client info
+		transaction.clientAddress = 'CLIENT';
+		transaction.request = new HTTPRequest(buildMessage(
+			harTransaction.request.startLine,
+			harTransaction.request.headers,
+			harTransaction.request.body
+		));
+
+		// * The HAR spec doesn't seem to define a way to say "this request failed and/or has no reply"?
+		// TODO - Figure this out
+		transaction.response = new HTTPResponse(buildMessage(
+			harTransaction.response.startLine,
+			harTransaction.response.headers,
+			harTransaction.response.body
+		));
+
+		return transaction;
+	}
+
 	public toJSON(): SerializedMessage {
 		const url = new URL(this.uri);
 		const requestMime = mimeType(this.request);
@@ -157,7 +182,7 @@ export default class HTTPTransaction {
 			id: this.id,
 			elapsed_time: this.elapsedTime,
 			transport: 'HTTP',
-			source: `${this.clientAddress}:${this.clientPort}`,
+			source: this.clientPort === undefined ? this.clientAddress : `${this.clientAddress}:${this.clientPort}`,
 			destination: `${url.protocol}//${url.hostname}`,
 			destination_path: url.pathname,
 			method: this.request.method,

--- a/src/session.ts
+++ b/src/session.ts
@@ -17,6 +17,7 @@ import PRUDPPacketLite from '@/nex/prudp-packetLite';
 import RawRMCPacket from '@/nex/raw-rmc-packet';
 import NPLNTransaction from '@/npln/npln-transaction';
 import PNSJSession from '@/pnsj-session';
+import HTTPTransaction from '@/http-transaction';
 import parseHTTPMessage, { HTTPMessageDirection } from '@/http-message';
 import type { PCAPFrame } from '@/pcap-parser';
 import type { SimplePacketBlock, EnhancedPacketBlock } from '@/pcapng-parser';
@@ -128,6 +129,8 @@ export default class Session extends EventEmitter {
 		let elapsedTime = 0;
 
 		for (const transaction of parser.transactions()) {
+			this.addSerializedMessage(HTTPTransaction.fromCharlesTransaction(transaction).toJSON());
+
 			for (const message of transaction.websocketMessages) {
 				const timestampSeconds = Number(message.startTime) / 1000;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -17,6 +17,7 @@ import PRUDPPacketLite from '@/nex/prudp-packetLite';
 import RawRMCPacket from '@/nex/raw-rmc-packet';
 import NPLNTransaction from '@/npln/npln-transaction';
 import PNSJSession from '@/pnsj-session';
+import HARParser from '@/har-parser';
 import HTTPTransaction from '@/http-transaction';
 import parseHTTPMessage, { HTTPMessageDirection } from '@/http-message';
 import type { PCAPFrame } from '@/pcap-parser';
@@ -73,6 +74,9 @@ export default class Session extends EventEmitter {
 				break;
 			case '.bin': // TODO - Replace this with a `parseBin` function that supports other .bin formats
 				this.parseProxideConnection(captureData); // TODO - Always assumes gRPC connections. Make this more generic?
+				break;
+			case '.har':
+				this.parseHAR(captureData);
 				break;
 			case '.pnsj':
 				this.parsePNSJSession(captureData);
@@ -332,6 +336,28 @@ export default class Session extends EventEmitter {
 			if (contentType.startsWith('application/grpc')) {
 				this.addSerializedMessage(NPLNTransaction.parseFromProxideTransaction(transaction).toJSON());
 			}
+		}
+
+		this.emitSerializedMessageList();
+	}
+
+	private parseHAR(captureData: Buffer): void {
+		const parser = new HARParser(captureData);
+		let elapsedTime = 0;
+
+		for (const transaction of parser.transactions()) {
+			const httpTransaction = HTTPTransaction.fromHARTransaction(transaction);
+			const timestampSeconds = transaction.startTime;
+
+			if (this.lastPacketTime !== 0) {
+				this.elapsedTime += timestampSeconds - this.lastPacketTime;
+				elapsedTime = this.elapsedTime;
+			}
+
+			this.lastPacketTime = timestampSeconds;
+			httpTransaction.elapsedTime = elapsedTime;
+
+			this.addSerializedMessage(httpTransaction.toJSON());
 		}
 
 		this.emitSerializedMessageList();

--- a/src/session.ts
+++ b/src/session.ts
@@ -212,7 +212,13 @@ export default class Session extends EventEmitter {
 		const parser = new FlowsParser(captureData);
 
 		for (const flow of parser.flows()) {
-			if (flow.type === 'http' && flow.websocket && flow.server_conn.address && flow.server_conn.sni) {
+			if (flow.type !== 'http') {
+				continue;
+			}
+
+			this.addSerializedMessage(HTTPTransaction.fromMitmproxyFlow(flow).toJSON());
+
+			if (flow.websocket && flow.server_conn.address && flow.server_conn.sni) {
 				for (const message of flow.websocket.messages) {
 					const stream = new ByteStream(message.content);
 					const packet = new PRUDPPacketLite(stream);

--- a/src/session.ts
+++ b/src/session.ts
@@ -171,6 +171,8 @@ export default class Session extends EventEmitter {
 		let elapsedTime = 0;
 
 		for (const transaction of parser.transactions()) {
+			this.addSerializedMessage(HTTPTransaction.fromCharlesTransaction(transaction).toJSON());
+
 			for (const message of transaction.websocketMessages) {
 				const timestampSeconds = new Date(message.startTime).getTime() / 1000;
 

--- a/src/types/serialized-message.ts
+++ b/src/types/serialized-message.ts
@@ -22,7 +22,7 @@ export type SerializedMessage = {
 	service?: string;
 	method?: string;
 	direction?: string;
-	status?: string;
+	status?: string | number; // * HTTP transactions use the numeric status code
 	overview_sections: {
 		title: string;
 		columns: number;

--- a/src/types/serialized-message.ts
+++ b/src/types/serialized-message.ts
@@ -2,6 +2,9 @@ export interface BasicSerializedField {
 	__displayTypeName?: string;
 	__typeName?: string;
 	__value?: any;
+	__saveable?: boolean; // * Lets the UI offer to save the field to disk
+	__bytes?: number[]; // * The fields raw bytes, for when `__value` holds a display form of them instead
+	__filename?: string; // * The name to suggest when saving
 }
 
 export interface ExpandableSerializedField extends BasicSerializedField {

--- a/src/types/serialized-message.ts
+++ b/src/types/serialized-message.ts
@@ -41,6 +41,7 @@ export type SerializedMessage = {
 		fields: {
 			name: string;
 			data: SerializedField;
+			language?: string; // * Triggers the UI to render the data in MonacoViewer rather than the normal collapsible system
 		}[];
 	}[];
 	stack_trace?: string;

--- a/src/types/serialized-message.ts
+++ b/src/types/serialized-message.ts
@@ -43,6 +43,7 @@ export type SerializedMessage = {
 			data: SerializedField;
 			language?: string; // * Triggers the UI to render the data in MonacoViewer rather than the normal collapsible system
 			bytes?: number[];
+			image?: string; // * Triggers the UI to render `bytes` as an image of this content type, rather than as text
 		}[];
 	}[];
 	stack_trace?: string;

--- a/src/types/serialized-message.ts
+++ b/src/types/serialized-message.ts
@@ -42,6 +42,7 @@ export type SerializedMessage = {
 			name: string;
 			data: SerializedField;
 			language?: string; // * Triggers the UI to render the data in MonacoViewer rather than the normal collapsible system
+			bytes?: number[];
 		}[];
 	}[];
 	stack_trace?: string;

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -8,6 +8,7 @@
   ],
   "compilerOptions": {
     "composite": true,
+    "moduleResolution": "bundler",
     "baseUrl": ".",
     "paths": {
       "@renderer/*": [


### PR DESCRIPTION
Resolves #37 and #33

### Changes:

- Adds support for HAR dumps
- Adds support for viewing HTTP transactions in the UI (only supported by Charles, flows, and HAR dumps). These transactions are shown in the UI just like other packets, and have the relevant information we use most often (paths, query params, headers, bodies, etc.). Not all data about the transaction is shown (such as timings and such) since we never really use that, but we can expand this later should we need it
- HTTP message bodies can be saved to disk (both request and response)
- HTTP message bodies that are images show the actual image in the UI
- HTTP message bodies which are text-based are displayed using [Monaco](https://github.com/microsoft/monaco-editor) (the library powering VSCode) since it has pretty rendering, syntax highlighting, and a built in API for formatting text
- HTTP message bodies which are text-based can be shown as both their raw form and in a formatted form (Monaco only ships with a formatter for JSON, HTML and CSS. We need to build formatters for other languages like XML)
- HTTP message bodies which are forms are displayed as both their text form and as a serialized form. Each form field can also be specifically saved to disk (so for example, you could save file being uploaded to DataStore)

### What this does not add:

- HPP support
- Live HTTP proxying
- HTTP transactions in pcap(ng) dumps. This requires a LOT more leg work, including handling SSL/TLS ourselves, reconstructing the raw TPC message packets, chunked payloads, etc. I would like to add this eventually, but it's a much more complex task

### Screenshots

Basic packet view:

<img width="1918" height="1024" alt="Screenshot 2026-09-01 at 8 32 24 PM" src="https://github.com/user-attachments/assets/f137c949-42e2-4001-af15-3dc3f2aedcd2" />

HTTP headers expanded:

<img width="1917" height="1024" alt="Screenshot 2026-09-01 at 8 33 15 PM" src="https://github.com/user-attachments/assets/57bfd707-cdd0-485b-918a-85e6e4bb4e45" />

Form plain text:

<img width="1919" height="1026" alt="Screenshot 2026-09-01 at 8 32 33 PM" src="https://github.com/user-attachments/assets/fcfa4ce6-7cb4-4c58-8072-21c950cf67f3" />

Form serialized expanded:

<img width="1919" height="1026" alt="Screenshot 2026-09-01 at 8 32 43 PM" src="https://github.com/user-attachments/assets/3bc837da-33c2-447e-88de-7ef83e4bb349" />

Formatted and syntax highlighted JSON:

<img width="1919" height="1025" alt="Screenshot 2026-09-01 at 8 35 12 PM" src="https://github.com/user-attachments/assets/0dc896d9-7aaa-4187-85c4-0a6dfefcfa15" />

Image response:

<img width="1918" height="1027" alt="Screenshot 2026-09-01 at 8 35 22 PM" src="https://github.com/user-attachments/assets/787f2044-f034-418a-a341-4a728ddc4ef9" />

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.